### PR TITLE
remove seq number from Header.msg

### DIFF
--- a/std_interfaces/msg/Header.msg
+++ b/std_interfaces/msg/Header.msg
@@ -2,9 +2,6 @@
 # This is generally used to communicate timestamped data
 # in a particular coordinate frame.
 
-# Sequence ID: consecutively increasing ID
-uint32 seq
-
 # Two-integer timestamp that is expressed as seconds and nanoseconds.
 builtin_interfaces/Time stamp
 


### PR DESCRIPTION
This has been proposed as far back as six years ago, but was avoided in ROS 1 to prevent disruption to existing code. The idea is that having a sequence number that is inconsistently set by the middleware, and often set by users, only to have the middleware override it, doesn't really make sense. Rather the middleware should give the sequence number to the subscriber through a separate channel (not as part of the message struct), and prevent the publishing user from setting it manually (it doesn't make sense for them to do so). Therefore it doesn't need to be a field in the `.msg`.

Also, unlike `stamp` and `frame_id`, `seq` is not needed to relate one piece of data to another. Both `stamp` and `frame_id` are values with global significance and are values that the middleware cannot realistically set automatically. Whereas `seq` is specific to a single publishing source, or topic depending on the middleware's behavior, and doesn't help coordinate the message instance with message instances from other sources or topics. It might be valid for messages to have sequence numbers if the source of the sequence numbers is generated by the user rather than the middleware, but is not needed in `Header.msg` interface. Another reason for keeping `stamp` in the header while `seq` should be removed, is that the middleware might provide the subscriber with a message received timestamp, but that is typically distinctly different from the creation of the data timestamp in the `Header.msg`.

Links to previous discussions about this issue are in this comment:

https://github.com/ros2/common_interfaces/issues/1#issuecomment-112621348

Request for comment.