### PR TITLE
disable many uncommonly used messages temporarly to save build time

### DIFF
--- a/geometry_msgs/CMakeLists.txt
+++ b/geometry_msgs/CMakeLists.txt
@@ -11,29 +11,33 @@ find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
 
 set(msg_files
+# TODO(wjwwood): re-enable all messages when build time is not so important.
+#                This will likely be the case when we have a proper build farm
+#                and/or we reduce the number of middlewares or languages we
+#                build for by default.
   "msg/Point.msg"
   "msg/Point32.msg"
-  "msg/PointStamped.msg"
-  "msg/Polygon.msg"
-  "msg/PolygonStamped.msg"
-  "msg/Pose.msg"
-  "msg/Pose2D.msg"
-  "msg/PoseArray.msg"
-  "msg/PoseStamped.msg"
-  "msg/PoseWithCovariance.msg"
-  "msg/PoseWithCovarianceStamped.msg"
+  # "msg/PointStamped.msg"
+  # "msg/Polygon.msg"
+  # "msg/PolygonStamped.msg"
+  # "msg/Pose.msg"
+  # "msg/Pose2D.msg"
+  # "msg/PoseArray.msg"
+  # "msg/PoseStamped.msg"
+  # "msg/PoseWithCovariance.msg"
+  # "msg/PoseWithCovarianceStamped.msg"
   "msg/Quaternion.msg"
-  "msg/QuaternionStamped.msg"
+  # "msg/QuaternionStamped.msg"
   "msg/Transform.msg"
   "msg/TransformStamped.msg"
-  "msg/Twist.msg"
-  "msg/TwistStamped.msg"
-  "msg/TwistWithCovariance.msg"
-  "msg/TwistWithCovarianceStamped.msg"
+  # "msg/Twist.msg"
+  # "msg/TwistStamped.msg"
+  # "msg/TwistWithCovariance.msg"
+  # "msg/TwistWithCovarianceStamped.msg"
   "msg/Vector3.msg"
-  "msg/Vector3Stamped.msg"
-  "msg/Wrench.msg"
-  "msg/WrenchStamped.msg"
+  # "msg/Vector3Stamped.msg"
+  # "msg/Wrench.msg"
+  # "msg/WrenchStamped.msg"
 )
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}

--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -13,32 +13,36 @@ find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
 
 set(msg_files
+# TODO(wjwwood): re-enable all messages when build time is not so important.
+#                This will likely be the case when we have a proper build farm
+#                and/or we reduce the number of middlewares or languages we
+#                build for by default.
   "msg/CameraInfo.msg"
   "msg/ChannelFloat32.msg"
   "msg/CompressedImage.msg"
-  "msg/FluidPressure.msg"
-  "msg/Illuminance.msg"
+  # "msg/FluidPressure.msg"
+  # "msg/Illuminance.msg"
   "msg/Image.msg"
   "msg/Imu.msg"
-  "msg/JointState.msg"
-  "msg/Joy.msg"
-  "msg/JoyFeedback.msg"
-  "msg/JoyFeedbackArray.msg"
-  "msg/LaserEcho.msg"
+  # "msg/JointState.msg"
+  # "msg/Joy.msg"
+  # "msg/JoyFeedback.msg"
+  # "msg/JoyFeedbackArray.msg"
+  # "msg/LaserEcho.msg"
   "msg/LaserScan.msg"
-  "msg/MagneticField.msg"
-  "msg/MultiDOFJointState.msg"
-  "msg/MultiEchoLaserScan.msg"
-  "msg/NavSatFix.msg"
-  "msg/NavSatStatus.msg"
+  # "msg/MagneticField.msg"
+  # "msg/MultiDOFJointState.msg"
+  # "msg/MultiEchoLaserScan.msg"
+  # "msg/NavSatFix.msg"
+  # "msg/NavSatStatus.msg"
   "msg/PointCloud.msg"
   "msg/PointCloud2.msg"
   "msg/PointField.msg"
-  "msg/Range.msg"
+  # "msg/Range.msg"
   "msg/RegionOfInterest.msg"
-  "msg/RelativeHumidity.msg"
-  "msg/Temperature.msg"
-  "msg/TimeReference.msg"
+  # "msg/RelativeHumidity.msg"
+  # "msg/Temperature.msg"
+  # "msg/TimeReference.msg"
 )
 set(srv_files
   "srv/SetCameraInfo.srv"

--- a/std_msgs/CMakeLists.txt
+++ b/std_msgs/CMakeLists.txt
@@ -11,36 +11,40 @@ find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files
+# TODO(wjwwood): re-enable all messages when build time is not so important.
+#                This will likely be the case when we have a proper build farm
+#                and/or we reduce the number of middlewares or languages we
+#                build for by default.
   "msg/Bool.msg"
-  "msg/Byte.msg"
-  "msg/ByteMultiArray.msg"
-  "msg/Char.msg"
-  "msg/ColorRGBA.msg"
-  "msg/Empty.msg"
+  # "msg/Byte.msg"
+  # "msg/ByteMultiArray.msg"
+  # "msg/Char.msg"
+  # "msg/ColorRGBA.msg"
+  # "msg/Empty.msg"
   "msg/Float32.msg"
-  "msg/Float32MultiArray.msg"
+  # "msg/Float32MultiArray.msg"
   "msg/Float64.msg"
-  "msg/Float64MultiArray.msg"
+  # "msg/Float64MultiArray.msg"
   "msg/Header.msg"
   "msg/Int16.msg"
-  "msg/Int16MultiArray.msg"
+  # "msg/Int16MultiArray.msg"
   "msg/Int32.msg"
-  "msg/Int32MultiArray.msg"
+  # "msg/Int32MultiArray.msg"
   "msg/Int64.msg"
-  "msg/Int64MultiArray.msg"
+  # "msg/Int64MultiArray.msg"
   "msg/Int8.msg"
-  "msg/Int8MultiArray.msg"
-  "msg/MultiArrayDimension.msg"
-  "msg/MultiArrayLayout.msg"
+  # "msg/Int8MultiArray.msg"
+  # "msg/MultiArrayDimension.msg"
+  # "msg/MultiArrayLayout.msg"
   "msg/String.msg"
   "msg/UInt16.msg"
-  "msg/UInt16MultiArray.msg"
+  # "msg/UInt16MultiArray.msg"
   "msg/UInt32.msg"
-  "msg/UInt32MultiArray.msg"
+  # "msg/UInt32MultiArray.msg"
   "msg/UInt64.msg"
-  "msg/UInt64MultiArray.msg"
+  # "msg/UInt64MultiArray.msg"
   "msg/UInt8.msg"
-  "msg/UInt8MultiArray.msg"
+  # "msg/UInt8MultiArray.msg"
 )
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}


### PR DESCRIPTION
As we discussed on the mailing list.

The only thing I could think we might do differently is that we could add an option to opt-in or opt-out of building these messages using an environment variable. On the one hand that's a strange (surprising) side effect, but on the other we could re-enable these messages for the nightly/packaging jobs more easily.