### PR TITLE
port missing interfaces from ROS1 common_msgs

### DIFF
--- a/diagnostic_msgs/CMakeLists.txt
+++ b/diagnostic_msgs/CMakeLists.txt
@@ -17,6 +17,7 @@ set(msg_files
 )
 set(srv_files
   "srv/SelfTest.srv"
+  "srv/AddDiagnostics.srv"
 )
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}

--- a/diagnostic_msgs/CMakeLists.txt
+++ b/diagnostic_msgs/CMakeLists.txt
@@ -16,8 +16,8 @@ set(msg_files
   "msg/KeyValue.msg"
 )
 set(srv_files
-  "srv/SelfTest.srv"
   "srv/AddDiagnostics.srv"
+  "srv/SelfTest.srv"
 )
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}

--- a/diagnostic_msgs/srv/AddDiagnostics.srv
+++ b/diagnostic_msgs/srv/AddDiagnostics.srv
@@ -1,0 +1,27 @@
+# This service is used as part of the process for loading analyzers at runtime,
+# and should be used by a loader script or program, not as a standalone service.
+# Information about dynamic addition of analyzers can be found at
+# http://wiki.ros.org/diagnostics/Tutorials/Adding%20Analyzers%20at%20Runtime
+
+# The load_namespace parameter defines the namespace where parameters for the
+# initialization of analyzers in the diagnostic aggregator have been loaded. The
+# value should be a global name (i.e. /my/name/space), not a relative
+# (my/name/space) or private (~my/name/space) name. Analyzers will not be added
+# if a non-global name is used. The call will also fail if the namespace
+# contains parameters that follow a namespace structure that does not conform to
+# that expected by the analyzer definitions. See
+# http://wiki.ros.org/diagnostics/Tutorials/Configuring%20Diagnostic%20Aggregators
+# and http://wiki.ros.org/diagnostics/Tutorials/Using%20the%20GenericAnalyzer
+# for examples of the structure of yaml files which are expected to have been
+# loaded into the namespace.
+string load_namespace
+---
+
+# True if diagnostic aggregator was updated with new diagnostics, False
+# otherwise. A false return value means that either there is a bond in the
+# aggregator which already used the requested namespace, or the initialization
+# of analyzers failed.
+bool success
+
+# Message with additional information about the success or failure
+string message

--- a/geometry_msgs/CMakeLists.txt
+++ b/geometry_msgs/CMakeLists.txt
@@ -11,6 +11,12 @@ find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
 
 set(msg_files
+  "msg/Accel.msg"
+  "msg/AccelStamped.msg"
+  "msg/AccelWithCovariance.msg"
+  "msg/AccelWithCovarianceStamped.msg"
+  "msg/Inertia.msg"
+  "msg/InertiaStamped.msg"
   "msg/Point.msg"
   "msg/Point32.msg"
   "msg/PointStamped.msg"

--- a/geometry_msgs/msg/Accel.msg
+++ b/geometry_msgs/msg/Accel.msg
@@ -1,0 +1,3 @@
+# This expresses acceleration in free space broken into its linear and angular parts.
+Vector3  linear
+Vector3  angular

--- a/geometry_msgs/msg/AccelStamped.msg
+++ b/geometry_msgs/msg/AccelStamped.msg
@@ -1,0 +1,3 @@
+# An accel with reference coordinate frame and timestamp
+std_msgs/Header header
+Accel accel

--- a/geometry_msgs/msg/AccelWithCovariance.msg
+++ b/geometry_msgs/msg/AccelWithCovariance.msg
@@ -1,0 +1,9 @@
+# This expresses acceleration in free space with uncertainty.
+
+Accel accel
+
+# Row-major representation of the 6x6 covariance matrix
+# The orientation parameters use a fixed-axis representation.
+# In order, the parameters are:
+# (x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)
+float64[36] covariance

--- a/geometry_msgs/msg/AccelWithCovarianceStamped.msg
+++ b/geometry_msgs/msg/AccelWithCovarianceStamped.msg
@@ -1,0 +1,3 @@
+# This represents an estimated accel with reference coordinate frame and timestamp.
+std_msgs/Header header
+AccelWithCovariance accel

--- a/geometry_msgs/msg/Inertia.msg
+++ b/geometry_msgs/msg/Inertia.msg
@@ -1,0 +1,16 @@
+# Mass [kg]
+float64 m
+
+# Center of mass [m]
+geometry_msgs/Vector3 com
+
+# Inertia Tensor [kg-m^2]
+#     | ixx ixy ixz |
+# I = | ixy iyy iyz |
+#     | ixz iyz izz |
+float64 ixx
+float64 ixy
+float64 ixz
+float64 iyy
+float64 iyz
+float64 izz

--- a/geometry_msgs/msg/InertiaStamped.msg
+++ b/geometry_msgs/msg/InertiaStamped.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+Inertia inertia

--- a/nav_msgs/CMakeLists.txt
+++ b/nav_msgs/CMakeLists.txt
@@ -22,6 +22,7 @@ set(msg_files
 set(srv_files
   "srv/GetMap.srv"
   "srv/GetPlan.srv"
+  "srv/SetMap.srv"
 )
 # TODO(wjwwood): port the action GetMap from ROS 1, once actions are supported.
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/nav_msgs/srv/SetMap.srv
+++ b/nav_msgs/srv/SetMap.srv
@@ -1,0 +1,6 @@
+# Set a new map together with an initial pose
+nav_msgs/OccupancyGrid map
+geometry_msgs/PoseWithCovarianceStamped initial_pose
+---
+bool success
+

--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
 
 set(msg_files
+  "msg/BatteryState.msg"
   "msg/CameraInfo.msg"
   "msg/ChannelFloat32.msg"
   "msg/CompressedImage.msg"

--- a/sensor_msgs/msg/BatteryState.msg
+++ b/sensor_msgs/msg/BatteryState.msg
@@ -1,0 +1,49 @@
+
+# Constants are chosen to match the enums in the linux kernel
+# defined in include/linux/power_supply.h as of version 3.7
+# The one difference is for style reasons the constants are
+# all uppercase not mixed case.
+
+# Power supply status constants
+uint8 POWER_SUPPLY_STATUS_UNKNOWN = 0
+uint8 POWER_SUPPLY_STATUS_CHARGING = 1
+uint8 POWER_SUPPLY_STATUS_DISCHARGING = 2
+uint8 POWER_SUPPLY_STATUS_NOT_CHARGING = 3
+uint8 POWER_SUPPLY_STATUS_FULL = 4
+
+# Power supply health constants
+uint8 POWER_SUPPLY_HEALTH_UNKNOWN = 0
+uint8 POWER_SUPPLY_HEALTH_GOOD = 1
+uint8 POWER_SUPPLY_HEALTH_OVERHEAT = 2
+uint8 POWER_SUPPLY_HEALTH_DEAD = 3
+uint8 POWER_SUPPLY_HEALTH_OVERVOLTAGE = 4
+uint8 POWER_SUPPLY_HEALTH_UNSPEC_FAILURE = 5
+uint8 POWER_SUPPLY_HEALTH_COLD = 6
+uint8 POWER_SUPPLY_HEALTH_WATCHDOG_TIMER_EXPIRE = 7
+uint8 POWER_SUPPLY_HEALTH_SAFETY_TIMER_EXPIRE = 8
+
+# Power supply technology (chemistry) constants
+uint8 POWER_SUPPLY_TECHNOLOGY_UNKNOWN = 0
+uint8 POWER_SUPPLY_TECHNOLOGY_NIMH = 1
+uint8 POWER_SUPPLY_TECHNOLOGY_LION = 2
+uint8 POWER_SUPPLY_TECHNOLOGY_LIPO = 3
+uint8 POWER_SUPPLY_TECHNOLOGY_LIFE = 4
+uint8 POWER_SUPPLY_TECHNOLOGY_NICD = 5
+uint8 POWER_SUPPLY_TECHNOLOGY_LIMN = 6
+
+std_msgs/Header  header
+float32 voltage          # Voltage in Volts (Mandatory)
+float32 current          # Negative when discharging (A)  (If unmeasured NaN)
+float32 charge           # Current charge in Ah  (If unmeasured NaN)
+float32 capacity         # Capacity in Ah (last full capacity)  (If unmeasured NaN)
+float32 design_capacity  # Capacity in Ah (design capacity)  (If unmeasured NaN)
+float32 percentage       # Charge percentage on 0 to 1 range  (If unmeasured NaN)
+uint8   power_supply_status     # The charging status as reported. Values defined above
+uint8   power_supply_health     # The battery health metric. Values defined above
+uint8   power_supply_technology # The battery chemistry. Values defined above
+bool    present          # True if the battery is present
+
+float32[] cell_voltage   # An array of individual cell voltages for each cell in the pack
+                         # If individual voltages unknown but number of cells known set each to NaN
+string location          # The location into which the battery is inserted. (slot number or plug)
+string serial_number     # The best approximation of the battery serial number

--- a/std_srvs/CMakeLists.txt
+++ b/std_srvs/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(rosidl_default_generators REQUIRED)
 
 set(srv_files
   "srv/Empty.srv"
+  "srv/SetBool.srv"
   "srv/Trigger.srv"
 )
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/std_srvs/srv/SetBool.srv
+++ b/std_srvs/srv/SetBool.srv
@@ -1,0 +1,4 @@
+bool data # e.g. for hardware enabling / disabling
+---
+bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages


### PR DESCRIPTION
Connects to https://github.com/ros2/common_interfaces/issues/27
Closes https://github.com/ros2/common_interfaces/issues/27

This PR doesn't include `SetBool.srv` from `std_srvs` to follow the "services names should carry semantic meaning" guideline