### PR TITLE
Reenable linting in sensor_msgs.

### DIFF
--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -55,6 +55,11 @@ install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION include/${PROJECT_NAME}
 )
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_export_dependencies(rosidl_default_runtime)
 ament_export_include_directories(include)
 

--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -57,6 +57,9 @@ install(DIRECTORY include/${PROJECT_NAME}/
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+
+  # Prevent copyright from being found, since it doesn't support BSD.
+  set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/sensor_msgs/package.xml
+++ b/sensor_msgs/package.xml
@@ -21,12 +21,7 @@
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_cmake_cppcheck</test_depend>
-  <test_depend>ament_cmake_cpplint</test_depend>
-  <test_depend>ament_cmake_flake8</test_depend>
-  <test_depend>ament_cmake_lint_cmake</test_depend>
-  <test_depend>ament_cmake_pep257</test_depend>
-  <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/sensor_msgs/package.xml
+++ b/sensor_msgs/package.xml
@@ -20,7 +20,13 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
-  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_cmake_cpplint</test_depend>
+  <test_depend>ament_cmake_flake8</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_pep257</test_depend>
+  <test_depend>ament_cmake_uncrustify</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
We enable all of the linters except for the copyright one,
which doesn't understand BSD right now.  All of the other
tests pass.

Signed-off-by: Chris Lalancette <clalancette@osrfoundation.org>

Fixes ros2/common_interfaces#32