### PR TITLE
Make all of the messages and services have a runtime dependency on ro…

### DIFF
--- a/actionlib_msgs/CMakeLists.txt
+++ b/actionlib_msgs/CMakeLists.txt
@@ -28,6 +28,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_default_runtime rosidl_runtime_cpp)
 
 ament_package()

--- a/actionlib_msgs/package.xml
+++ b/actionlib_msgs/package.xml
@@ -16,6 +16,7 @@
 
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_runtime_cpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>

--- a/builtin_interfaces/CMakeLists.txt
+++ b/builtin_interfaces/CMakeLists.txt
@@ -21,6 +21,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_default_runtime rosidl_runtime_cpp)
 
 ament_package()

--- a/builtin_interfaces/CMakeLists.txt
+++ b/builtin_interfaces/CMakeLists.txt
@@ -14,6 +14,9 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(rosidl_runtime_cpp REQUIRED)
+
+include_directories(${rosidl_runtime_cpp_INCLUDE_DIRS})
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Duration.msg"

--- a/builtin_interfaces/package.xml
+++ b/builtin_interfaces/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_runtime_cpp</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
 

--- a/builtin_interfaces/package.xml
+++ b/builtin_interfaces/package.xml
@@ -11,6 +11,8 @@
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
+  <build_depend>rosidl_runtime_cpp</build_depend>
+
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>rosidl_runtime_cpp</exec_depend>
 

--- a/diagnostic_msgs/CMakeLists.txt
+++ b/diagnostic_msgs/CMakeLists.txt
@@ -32,6 +32,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_default_runtime rosidl_runtime_cpp)
 
 ament_package()

--- a/diagnostic_msgs/package.xml
+++ b/diagnostic_msgs/package.xml
@@ -18,6 +18,7 @@
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_runtime_cpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>

--- a/geometry_msgs/CMakeLists.txt
+++ b/geometry_msgs/CMakeLists.txt
@@ -53,6 +53,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_default_runtime rosidl_runtime_cpp)
 
 ament_package()

--- a/geometry_msgs/package.xml
+++ b/geometry_msgs/package.xml
@@ -14,6 +14,7 @@
   <build_depend>std_msgs</build_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_runtime_cpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>

--- a/nav_msgs/CMakeLists.txt
+++ b/nav_msgs/CMakeLists.txt
@@ -38,6 +38,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_default_runtime rosidl_runtime_cpp)
 
 ament_package()

--- a/nav_msgs/package.xml
+++ b/nav_msgs/package.xml
@@ -18,6 +18,7 @@
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_runtime_cpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>

--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -67,7 +67,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_default_runtime rosidl_runtime_cpp)
 ament_export_include_directories(include)
 
 ament_package()

--- a/sensor_msgs/package.xml
+++ b/sensor_msgs/package.xml
@@ -18,6 +18,7 @@
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_runtime_cpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/shape_msgs/CMakeLists.txt
+++ b/shape_msgs/CMakeLists.txt
@@ -28,6 +28,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_default_runtime rosidl_runtime_cpp)
 
 ament_package()

--- a/shape_msgs/package.xml
+++ b/shape_msgs/package.xml
@@ -15,6 +15,7 @@
 
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_runtime_cpp</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
 

--- a/std_msgs/CMakeLists.txt
+++ b/std_msgs/CMakeLists.txt
@@ -54,6 +54,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_default_runtime rosidl_runtime_cpp)
 
 ament_package()

--- a/std_msgs/package.xml
+++ b/std_msgs/package.xml
@@ -15,6 +15,7 @@
 
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_runtime_cpp</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
 

--- a/std_srvs/CMakeLists.txt
+++ b/std_srvs/CMakeLists.txt
@@ -14,6 +14,8 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(rosidl_runtime_cpp REQUIRED)
+include_directories(${rosidl_runtime_cpp_INCLUDE_DIRS})
 
 set(srv_files
   "srv/Empty.srv"

--- a/std_srvs/CMakeLists.txt
+++ b/std_srvs/CMakeLists.txt
@@ -25,6 +25,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_default_runtime rosidl_runtime_cpp)
 
 ament_package()

--- a/std_srvs/package.xml
+++ b/std_srvs/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_runtime_cpp</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
 

--- a/std_srvs/package.xml
+++ b/std_srvs/package.xml
@@ -11,6 +11,8 @@
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
+  <build_depend>rosidl_runtime_cpp</build_depend>
+
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>rosidl_runtime_cpp</exec_depend>
 

--- a/stereo_msgs/CMakeLists.txt
+++ b/stereo_msgs/CMakeLists.txt
@@ -26,6 +26,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_default_runtime rosidl_runtime_cpp)
 
 ament_package()

--- a/stereo_msgs/package.xml
+++ b/stereo_msgs/package.xml
@@ -15,6 +15,7 @@
   <build_depend>std_msgs</build_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_runtime_cpp</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 

--- a/trajectory_msgs/CMakeLists.txt
+++ b/trajectory_msgs/CMakeLists.txt
@@ -30,6 +30,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_default_runtime rosidl_runtime_cpp)
 
 ament_package()

--- a/trajectory_msgs/package.xml
+++ b/trajectory_msgs/package.xml
@@ -18,6 +18,7 @@
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_runtime_cpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>

--- a/visualization_msgs/CMakeLists.txt
+++ b/visualization_msgs/CMakeLists.txt
@@ -36,6 +36,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_default_runtime rosidl_runtime_cpp)
 
 ament_package()

--- a/visualization_msgs/package.xml
+++ b/visualization_msgs/package.xml
@@ -18,6 +18,7 @@
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_runtime_cpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
…sidl_runtime_cpp.

Going forward, they are all going to need a header file
from rosidl_runtime_cpp.  Therefore, we make sure they all
properly export this as a runtime dependency.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

connects to ros2/ros2#393

See CI in ros2/rosidl#231