### PR TITLE
create common_interfaces metapackage

### DIFF
--- a/common_interfaces/CMakeLists.txt
+++ b/common_interfaces/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(common_interfaces)
+
+find_package(ament_cmake REQUIRED)
+
+ament_package()

--- a/common_interfaces/package.xml
+++ b/common_interfaces/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>common_interfaces</name>
+  <version>0.0.2</version>
+  <description>A package containing some message definitions used in the implementation or actions.</description>
+  <maintainer email="william@osrfoundation.org">William Woodall</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>actionlib_msgs</exec_depend>
+  <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>shape_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>std_srvs</exec_depend>
+  <exec_depend>stereo_msgs</exec_depend>
+  <exec_depend>trajectory_msgs</exec_depend>
+  <exec_depend>visualization_msgs</exec_depend>
+
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/common_interfaces/package.xml
+++ b/common_interfaces/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>common_interfaces</name>
-  <version>0.0.2</version>
+  <version>0.0.3</version>
   <description>common_interfaces contains messages and services that are widely used by other ROS packages.</description>
   <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
   <license>Apache License 2.0</license>

--- a/common_interfaces/package.xml
+++ b/common_interfaces/package.xml
@@ -4,7 +4,7 @@
   <name>common_interfaces</name>
   <version>0.0.2</version>
   <description>A package containing some message definitions used in the implementation or actions.</description>
-  <maintainer email="william@osrfoundation.org">William Woodall</maintainer>
+  <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/common_interfaces/package.xml
+++ b/common_interfaces/package.xml
@@ -3,7 +3,7 @@
 <package format="2">
   <name>common_interfaces</name>
   <version>0.0.2</version>
-  <description>A package containing some message definitions used in the implementation or actions.</description>
+  <description>common_interfaces contains messages and services that are widely used by other ROS packages.</description>
   <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
   <license>Apache License 2.0</license>
 

--- a/common_interfaces/package.xml
+++ b/common_interfaces/package.xml
@@ -22,8 +22,6 @@
   <exec_depend>trajectory_msgs</exec_depend>
   <exec_depend>visualization_msgs</exec_depend>
 
-  <test_depend>ament_lint_common</test_depend>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
this came up a few times and more often since we started shipping binaries.
Creating this metapackage has 2 benefits:
- allow people to install all common message packages with a single debian package
- show an example of how metapackages look like in ROS2

One remaining question though: we renamed all message packages from `foo_interfaces` to `foo_msgs` a while ago to simplify the mapping between ros1 and ros2 messages. Should this package be named common_msgs like its' ROS1 equivalent? If so should we also rename this repository accordingly ?