### PR TITLE
member of rosidl_interfaces_packages group

### DIFF
--- a/actionlib_msgs/package.xml
+++ b/actionlib_msgs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>actionlib_msgs</name>
   <version>0.0.3</version>
   <description>A package containing some message definitions used in the implementation or actions.</description>
@@ -19,6 +19,8 @@
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interfaces_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/actionlib_msgs/package.xml
+++ b/actionlib_msgs/package.xml
@@ -20,7 +20,7 @@
 
   <test_depend>ament_lint_common</test_depend>
 
-  <member_of_group>rosidl_interfaces_packages</member_of_group>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/diagnostic_msgs/package.xml
+++ b/diagnostic_msgs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>diagnostic_msgs</name>
   <version>0.0.3</version>
   <description>A package containing some diagnostics related message and service definitions.</description>
@@ -21,6 +21,8 @@
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interfaces_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/diagnostic_msgs/package.xml
+++ b/diagnostic_msgs/package.xml
@@ -22,7 +22,7 @@
 
   <test_depend>ament_lint_common</test_depend>
 
-  <member_of_group>rosidl_interfaces_packages</member_of_group>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/geometry_msgs/package.xml
+++ b/geometry_msgs/package.xml
@@ -18,7 +18,7 @@
 
   <test_depend>ament_lint_common</test_depend>
 
-  <member_of_group>rosidl_interfaces_packages</member_of_group>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/geometry_msgs/package.xml
+++ b/geometry_msgs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>geometry_msgs</name>
   <version>0.0.3</version>
   <description>A package containing some geometry related message definitions.</description>
@@ -17,6 +17,8 @@
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interfaces_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nav_msgs/package.xml
+++ b/nav_msgs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>nav_msgs</name>
   <version>0.0.3</version>
   <description>A package containing some navigation related message and service definitions.</description>
@@ -21,6 +21,8 @@
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interfaces_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nav_msgs/package.xml
+++ b/nav_msgs/package.xml
@@ -22,7 +22,7 @@
 
   <test_depend>ament_lint_common</test_depend>
 
-  <member_of_group>rosidl_interfaces_packages</member_of_group>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/sensor_msgs/package.xml
+++ b/sensor_msgs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>sensor_msgs</name>
   <version>0.0.3</version>
   <description>A package containing some sensor data related message and service definitions.</description>
@@ -22,6 +22,8 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interfaces_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/sensor_msgs/package.xml
+++ b/sensor_msgs/package.xml
@@ -23,7 +23,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
-  <member_of_group>rosidl_interfaces_packages</member_of_group>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/shape_msgs/package.xml
+++ b/shape_msgs/package.xml
@@ -18,7 +18,7 @@
 
   <test_depend>ament_lint_common</test_depend>
 
-  <member_of_group>rosidl_interfaces_packages</member_of_group>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/shape_msgs/package.xml
+++ b/shape_msgs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>shape_msgs</name>
   <version>0.0.3</version>
   <description>A package containing some message definitions which describe geometric shapes.</description>
@@ -17,6 +17,8 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interfaces_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/std_msgs/package.xml
+++ b/std_msgs/package.xml
@@ -18,7 +18,7 @@
 
   <test_depend>ament_lint_common</test_depend>
 
-  <member_of_group>rosidl_interfaces_packages</member_of_group>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/std_msgs/package.xml
+++ b/std_msgs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>std_msgs</name>
   <version>0.0.3</version>
   <description>A package containing some standard message definitions.</description>
@@ -17,6 +17,8 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interfaces_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/std_srvs/package.xml
+++ b/std_srvs/package.xml
@@ -15,7 +15,7 @@
 
   <test_depend>ament_lint_common</test_depend>
 
-  <member_of_group>rosidl_interfaces_packages</member_of_group>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/std_srvs/package.xml
+++ b/std_srvs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>std_srvs</name>
   <version>0.0.3</version>
   <description>A package containing some standard service definitions.</description>
@@ -14,6 +14,8 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interfaces_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/stereo_msgs/package.xml
+++ b/stereo_msgs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>stereo_msgs</name>
   <version>0.0.3</version>
   <description>A package containing some stereo camera related message definitions.</description>
@@ -19,6 +19,8 @@
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interfaces_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/stereo_msgs/package.xml
+++ b/stereo_msgs/package.xml
@@ -20,7 +20,7 @@
 
   <test_depend>ament_lint_common</test_depend>
 
-  <member_of_group>rosidl_interfaces_packages</member_of_group>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/trajectory_msgs/package.xml
+++ b/trajectory_msgs/package.xml
@@ -22,7 +22,7 @@
 
   <test_depend>ament_lint_common</test_depend>
 
-  <member_of_group>rosidl_interfaces_packages</member_of_group>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/trajectory_msgs/package.xml
+++ b/trajectory_msgs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>trajectory_msgs</name>
   <version>0.0.3</version>
   <description>A package containing some robot trajectory message definitions.</description>
@@ -21,6 +21,8 @@
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interfaces_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/visualization_msgs/package.xml
+++ b/visualization_msgs/package.xml
@@ -22,7 +22,7 @@
 
   <test_depend>ament_lint_common</test_depend>
 
-  <member_of_group>rosidl_interfaces_packages</member_of_group>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/visualization_msgs/package.xml
+++ b/visualization_msgs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>visualization_msgs</name>
   <version>0.0.3</version>
   <description>A package containing some visualization and interaction related message definitions.</description>
@@ -21,6 +21,8 @@
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interfaces_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Follow-up of https://github.com/ament/ament_tools/pull/168.
Opening this to gather feedback as of how we should call the group containing ros IDL files.
This PR uses `interface_packages` but I'm open to alternatives