### PR TITLE
add rosgraph_msgs package with Clock message

### DIFF
--- a/rosgraph_msgs/CMakeLists.txt
+++ b/rosgraph_msgs/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(rosgraph_msgs)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # we dont use add_compile_options with pedantic in message packages
+  # because the Python C extensions dont comply with it
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+set(msg_files
+  "msg/Clock.msg"
+)
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  DEPENDENCIES builtin_interfaces
+  ADD_LINTER_TESTS
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+
+ament_package()

--- a/rosgraph_msgs/msg/Clock.msg
+++ b/rosgraph_msgs/msg/Clock.msg
@@ -1,4 +1,3 @@
-# roslib/Clock is used for publishing simulated time in ROS.
 # This message simply communicates the current time.
 # For more information, see http://www.ros.org/wiki/Clock
 builtin_interfaces/Time clock

--- a/rosgraph_msgs/msg/Clock.msg
+++ b/rosgraph_msgs/msg/Clock.msg
@@ -1,0 +1,4 @@
+# roslib/Clock is used for publishing simulated time in ROS.
+# This message simply communicates the current time.
+# For more information, see http://www.ros.org/wiki/Clock
+builtin_interfaces/Time clock

--- a/rosgraph_msgs/package.xml
+++ b/rosgraph_msgs/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rosgraph_msgs</name>
+  <version>0.4.0</version>
+  <description>
+    Messages relating to the ROS Computation Graph.
+    These are generally considered to be low-level messages that end users do not interact with.
+  </description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <build_depend>builtin_interfaces</build_depend>
+
+  <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Fixes ros2/ros1_bridge#104. Connect to ros2/ros1_bridge#104.

This adds the `Clock` message from the [rosgraph_msgs](https://github.com/ros/ros_comm_msgs/blob/indigo-devel/rosgraph_msgs) package.

The other two messages fro ROS 1 seem to not have a 1-to-1 equivalent in ROS 2 therefore I didn't add them at this point.