### PR TITLE
Include sstream on header that needs it

### DIFF
--- a/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp
+++ b/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp
@@ -38,6 +38,7 @@
 
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <cstdarg>
+#include <sstream>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Prevents the following compile error when using the header:

~~~
/opt/ros/bouncy/include/sensor_msgs/impl/point_cloud2_iterator.hpp:73:23: error: aggregate 'std::stringstream err' has incomplete type and cannot be defined
    std::stringstream err;
                      ^~~
~~~