### PR TITLE
New package, unique_identifier_msgs

### DIFF
--- a/unique_identifier_msgs/CHANGELOG.rst
+++ b/unique_identifier_msgs/CHANGELOG.rst
@@ -1,0 +1,35 @@
+Change history
+==============
+
+1.1.0 (2018-11-01)
+------------------
+* Name change: uuid_msgs -> unique_identifier_msgs
+
+1.0.4 (2014-04-30)
+------------------
+
+ * add architecture independent tag
+
+1.0.1 (2013-03-25)
+-------------------
+
+ * Hydro release update.
+
+1.0.0 (2013-03-18)
+-------------------
+
+ * Hydro release.
+ * Convert to catkin (`#1`_).
+
+0.9.0 (2013-01-03)
+------------------
+
+ * Initial release to Groovy.
+
+0.8.0 (2012-07-19)
+------------------
+
+ * Initial release to Fuerte.
+ * Provides uuid_msgs/UniqueID message.
+
+.. _`#1`: https://github.com/ros-geographic-info/unique_identifier/issues/1

--- a/unique_identifier_msgs/CMakeLists.txt
+++ b/unique_identifier_msgs/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.5)
+project(unique_identifier_msgs)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # we dont use add_compile_options with pedantic in message packages
+  # because the Python C extensions dont comply with it
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(std_msgs REQUIRED)
+
+set(msg_files
+  "msg/UniqueID.msg"
+)
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  DEPENDENCIES std_msgs
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+
+ament_package()

--- a/unique_identifier_msgs/msg/UniqueID.msg
+++ b/unique_identifier_msgs/msg/UniqueID.msg
@@ -1,0 +1,6 @@
+# A universally unique identifier (UUID).
+#
+#  http://en.wikipedia.org/wiki/Universally_unique_identifier
+#  http://tools.ietf.org/html/rfc4122.html
+
+uint8[16] uuid

--- a/unique_identifier_msgs/package.xml
+++ b/unique_identifier_msgs/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+
+  <name>unique_identifier_msgs</name>
+  <version>1.1.0</version>
+  <description>
+    ROS messages for universally unique identifiers.
+  </description>
+  <maintainer email="jack.oquin@gmail.com">Jack O'Quin</maintainer>
+  <author>Jack O'Quin</author>
+  <license>BSD</license>
+  <url>http://ros.org/wiki/unique_identifier_msgs</url>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <depend>std_msgs</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+
+</package>


### PR DESCRIPTION
There was a suggestion over at https://github.com/ros2/ros2/issues/593 to migrate `uuid_msgs` to `common_interfaces`. 

I'd also like to see it here - making use of a unique identifier became a very common thing to do once we started doing so.