### PR TITLE
Add GetInteractiveMarkers.srv

### DIFF
--- a/visualization_msgs/CMakeLists.txt
+++ b/visualization_msgs/CMakeLists.txt
@@ -28,8 +28,13 @@ set(msg_files
   "msg/MarkerArray.msg"
   "msg/MenuEntry.msg"
 )
+set(srv_files
+  "srv/GetInteractiveMarkers.srv"
+)
+
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
+  ${srv_files}
   DEPENDENCIES builtin_interfaces geometry_msgs std_msgs
   ADD_LINTER_TESTS
 )

--- a/visualization_msgs/srv/GetInteractiveMarkers.srv
+++ b/visualization_msgs/srv/GetInteractiveMarkers.srv
@@ -1,0 +1,12 @@
+---
+# Identifier for the interactive marker server.
+string server_id
+
+# Sequence number.
+# Set to the sequence number of the latest update message
+# at the time the server received the request.
+# Clients use this to detect if any updates were missed.
+uint64 sequence_number
+
+# All interactive markers provided by the server.
+InteractiveMarker[] markers

--- a/visualization_msgs/srv/GetInteractiveMarkers.srv
+++ b/visualization_msgs/srv/GetInteractiveMarkers.srv
@@ -1,7 +1,4 @@
 ---
-# Identifier for the interactive marker server.
-string server_id
-
 # Sequence number.
 # Set to the sequence number of the latest update message
 # at the time the server received the request.


### PR DESCRIPTION
This service is meant to replace use of InteractiveMarkerInit.msg on a latched topic.

Connects to https://github.com/ros-visualization/interactive_markers/issues/42