### PR TITLE
Make Quaternion valid by default

### DIFF
--- a/geometry_msgs/msg/Quaternion.msg
+++ b/geometry_msgs/msg/Quaternion.msg
@@ -1,6 +1,6 @@
 # This represents an orientation in free space in quaternion form.
 
-float64 x
-float64 y
-float64 z
-float64 w
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1


### PR DESCRIPTION
It was often a gotcha in ROS1 that creating a default `Quaternion` object didn't give you the identity quaternion (`w,x,y,z == 1,0,0,0`) but rather an invalid quaternion with everything initialized to zero. I always thought this was the perfect use of default values in the `.msg` file. Any particular reason why this hasn't been done already?