### PR TITLE
Add notice that actionlib_msgs is deprecated

### DIFF
--- a/actionlib_msgs/README.md
+++ b/actionlib_msgs/README.md
@@ -1,0 +1,2 @@
+This package is **deprecated** and exists to support bridging ROS 1 action topics.
+For ROS 2 actions, see [action_msgs](https://github.com/ros2/rcl_interfaces/tree/master/action_msgs).

--- a/actionlib_msgs/package.xml
+++ b/actionlib_msgs/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>actionlib_msgs</name>
   <version>0.8.0</version>
-  <description>A package containing some message definitions used in the implementation of actions.</description>
+  <description>A package containing some message definitions used in the implementation of ROS 1 actions.</description>
   <maintainer email="william@osrfoundation.org">William Woodall</maintainer>
   <license>Apache License 2.0</license>
 

--- a/actionlib_msgs/package.xml
+++ b/actionlib_msgs/package.xml
@@ -24,5 +24,9 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+
+    <deprecated>
+      This package will be removed in a future ROS distro, once the ROS 1 bridge supports actions.
+    </deprecated>
   </export>
 </package>


### PR DESCRIPTION
Related to https://github.com/ros2/common_interfaces/issues/64

If there's better mechanism for signaling the deprecation of a package, please advise.