### PR TITLE
Add the YUY2 image encoding

### DIFF
--- a/sensor_msgs/include/sensor_msgs/image_encodings.hpp
+++ b/sensor_msgs/include/sensor_msgs/image_encodings.hpp
@@ -96,9 +96,11 @@ const char BAYER_GBRG16[] = "bayer_gbrg16";
 const char BAYER_GRBG16[] = "bayer_grbg16";
 
 // Miscellaneous
-// This is the UYVY version of YUV422 codec http://www.fourcc.org/yuv.php#UYVY
-// with an 8-bit depth
+// YUV 4:2:2 encodings with an 8-bit depth
+// UYUV version: http://www.fourcc.org/pixel-format/yuv-uyvy
 const char YUV422[] = "yuv422";
+// YUYV version: http://www.fourcc.org/pixel-format/yuv-yuy2/
+const char YUV422_YUY2[] = "yuv422_yuy2";
 
 // Prefixes for abstract image encodings
 const char ABSTRACT_ENCODING_PREFIXES[][5] = {
@@ -186,7 +188,9 @@ static inline int numChannels(const std::string & encoding)
     }
   }
 
-  if (encoding == YUV422) {
+  if (encoding == YUV422 ||
+    encoding == YUV422_YUY2)
+  {
     return 2;
   }
 
@@ -244,7 +248,9 @@ static inline int bitDepth(const std::string & encoding)
     }
   }
 
-  if (encoding == YUV422) {
+  if (encoding == YUV422 ||
+    encoding == YUV422_YUY2)
+  {
     return 8;
   }
 

--- a/sensor_msgs/test/test_image_encodings.cpp
+++ b/sensor_msgs/test/test_image_encodings.cpp
@@ -52,6 +52,8 @@ TEST(sensor_msgs, NumChannels)
   ASSERT_EQ(sensor_msgs::image_encodings::numChannels("64FC"), 1);
   ASSERT_EQ(sensor_msgs::image_encodings::numChannels("64FC3"), 3);
   ASSERT_EQ(sensor_msgs::image_encodings::numChannels("64FC10"), 10);
+  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("yuv422"), 2);
+  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("yuv422_yuy2"), 2);
 }
 
 TEST(sensor_msgs, bitDepth)
@@ -70,4 +72,6 @@ TEST(sensor_msgs, bitDepth)
   ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("64FC"), 64);
   ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("64FC3"), 64);
   ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("64FC10"), 64);
+  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("yuv422"), 8);
+  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("yuv422_yuy2"), 8);
 }


### PR DESCRIPTION
This adds the YUY2/YUYV version of the YUV 4:2:2 image encoding, as discussed in #76 .

I chose the name `YUV422_YUY2`, to use the most popular fourcc code `YUY2` and try to be consistent with the existing `YUV422` encoding.
