### PR TITLE
Add common linters as test dependencies

### DIFF
--- a/common_interfaces/CMakeLists.txt
+++ b/common_interfaces/CMakeLists.txt
@@ -4,4 +4,9 @@ project(common_interfaces NONE)
 
 find_package(ament_cmake REQUIRED)
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()

--- a/common_interfaces/package.xml
+++ b/common_interfaces/package.xml
@@ -9,6 +9,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  
   <exec_depend>actionlib_msgs</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>diagnostic_msgs</exec_depend>

--- a/common_interfaces/package.xml
+++ b/common_interfaces/package.xml
@@ -9,9 +9,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <test_depend>ament_lint_common</test_depend>
-  <test_depend>ament_lint_auto</test_depend>
-  
   <exec_depend>actionlib_msgs</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>diagnostic_msgs</exec_depend>
@@ -24,6 +21,9 @@
   <exec_depend>stereo_msgs</exec_depend>
   <exec_depend>trajectory_msgs</exec_depend>
   <exec_depend>visualization_msgs</exec_depend>
+
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/common_interfaces/package.xml
+++ b/common_interfaces/package.xml
@@ -22,8 +22,8 @@
   <exec_depend>trajectory_msgs</exec_depend>
   <exec_depend>visualization_msgs</exec_depend>
 
-  <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Included ament_lint_common and ament_lint_auto as test dependencies

Signed-off-by: Jorge J. Perez <jjperez@ekumenlabs.com>