### PR TITLE
Homogenize const types with usage in action and type storage

### DIFF
--- a/visualization_msgs/msg/ImageMarker.msg
+++ b/visualization_msgs/msg/ImageMarker.msg
@@ -1,11 +1,11 @@
-uint8 CIRCLE=0
-uint8 LINE_STRIP=1
-uint8 LINE_LIST=2
-uint8 POLYGON=3
-uint8 POINTS=4
+int32 CIRCLE=0
+int32 LINE_STRIP=1
+int32 LINE_LIST=2
+int32 POLYGON=3
+int32 POINTS=4
 
-uint8 ADD=0
-uint8 REMOVE=1
+int32 ADD=0
+int32 REMOVE=1
 
 std_msgs/Header header
 # Namespace which is used with the id to form a unique id.

--- a/visualization_msgs/msg/Marker.msg
+++ b/visualization_msgs/msg/Marker.msg
@@ -4,23 +4,23 @@
 #
 # for more information on using this message with rviz.
 
-uint8 ARROW=0
-uint8 CUBE=1
-uint8 SPHERE=2
-uint8 CYLINDER=3
-uint8 LINE_STRIP=4
-uint8 LINE_LIST=5
-uint8 CUBE_LIST=6
-uint8 SPHERE_LIST=7
-uint8 POINTS=8
-uint8 TEXT_VIEW_FACING=9
-uint8 MESH_RESOURCE=10
-uint8 TRIANGLE_LIST=11
+int32 ARROW=0
+int32 CUBE=1
+int32 SPHERE=2
+int32 CYLINDER=3
+int32 LINE_STRIP=4
+int32 LINE_LIST=5
+int32 CUBE_LIST=6
+int32 SPHERE_LIST=7
+int32 POINTS=8
+int32 TEXT_VIEW_FACING=9
+int32 MESH_RESOURCE=10
+int32 TRIANGLE_LIST=11
 
-uint8 ADD=0
-uint8 MODIFY=0
-uint8 DELETE=2
-uint8 DELETEALL=3
+int32 ADD=0
+int32 MODIFY=0
+int32 DELETE=2
+int32 DELETEALL=3
 
 # Header for timestamp and frame id.
 std_msgs/Header header


### PR DESCRIPTION
This is a follow up to the [Aggregate Foxy Message API Review](https://github.com/ros2/common_interfaces/pull/86)

In both Marker and ImageMarker the constants are all uint8

https://github.com/ros2/common_interfaces/blob/519e851f6ac71262e45b6e5ca66bce653a72948d/visualization_msgs/msg/ImageMarker.msg#L1-L8

However the action and type they are used in are int32

https://github.com/ros2/common_interfaces/blob/519e851f6ac71262e45b6e5ca66bce653a72948d/visualization_msgs/msg/ImageMarker.msg#L15-L18

This proposes to homogenize them by changing the const's declared type to be consistent.