### PR TITLE
Add nav_msgs/Particle and nav_msgs/ParticleCloud messages

### DIFF
--- a/nav_msgs/CMakeLists.txt
+++ b/nav_msgs/CMakeLists.txt
@@ -21,6 +21,8 @@ set(msg_files
   "msg/MapMetaData.msg"
   "msg/OccupancyGrid.msg"
   "msg/Odometry.msg"
+  "msg/Particle.msg"
+  "msg/ParticleCloud.msg"
   "msg/Path.msg"
 )
 set(srv_files

--- a/nav_msgs/README.md
+++ b/nav_msgs/README.md
@@ -11,6 +11,8 @@ For more information about ROS 2 interfaces, see [index.ros2.org](https://index.
 * [MapMetaData](msg/MapMetaData.msg): Basic information about the characteristics of the OccupancyGrid.
 * [OccupancyGrid](msg/OccupancyGrid.msg): Represents a 2-D grid map, in which each cell represents the probability of occupancy.
 * [Odometry](msg/Odometry.msg): This represents an estimate of a position and velocity in free space.
+* [Particle](msg/Particle.msg): This represents an individual particle with weight produced by a particle filter.
+* [ParticleCloud](msg/ParticleCloud.msg): This represents a particle cloud containing particle poses and weights.
 * [Path](msg/Path.msg): An array of poses that represents a Path for a robot to follow.
 
 ## Services (.srv)

--- a/nav_msgs/msg/Particle.msg
+++ b/nav_msgs/msg/Particle.msg
@@ -1,0 +1,5 @@
+# This represents an individual particle with weight produced by a particle filter
+
+geometry_msgs/Pose pose
+
+float64 weight

--- a/nav_msgs/msg/ParticleCloud.msg
+++ b/nav_msgs/msg/ParticleCloud.msg
@@ -1,0 +1,6 @@
+# This represents a particle cloud containing particle poses and weights
+
+std_msgs/Header header
+
+# Array of particles in the cloud
+Particle[] particles


### PR DESCRIPTION
Signed-off-by: Sarthak Mittal <sarthakmittal2608@gmail.com>

As per https://github.com/ros2/rviz/issues/538 and https://github.com/ros-planning/navigation2/issues/1623, I propose adding ```nav_msgs/Particle``` and ```nav_msgs/ParticleCloud``` messages to represent particles/particle clouds produced by particle filters.