### PR TITLE
Update ColorRGBA.msg

### DIFF
--- a/std_msgs/msg/ColorRGBA.msg
+++ b/std_msgs/msg/ColorRGBA.msg
@@ -1,4 +1,4 @@
 float32 r
 float32 g
 float32 b
-float32 a
+float32 a 1


### PR DESCRIPTION
Setting the alpha channel to 1 should help a lot of people who wonder why their marker is not visible in RVIZ