### PR TITLE
Backport fix for sensor_msgs/fill_image.hpp missing header to Dashing #125 

### DIFF
--- a/sensor_msgs/include/sensor_msgs/fill_image.hpp
+++ b/sensor_msgs/include/sensor_msgs/fill_image.hpp
@@ -36,6 +36,7 @@
 #ifndef SENSOR_MSGS__FILL_IMAGE_HPP_
 #define SENSOR_MSGS__FILL_IMAGE_HPP_
 
+#include <cstring>
 #include <string>
 
 #include "sensor_msgs/msg/image.hpp"
@@ -67,7 +68,7 @@ static inline bool fillImage(
   image.step = step_arg;
   size_t st0 = (step_arg * rows_arg);
   image.data.resize(st0);
-  memcpy(&image.data[0], data_arg, st0);
+  std::memcpy(&image.data[0], data_arg, st0);
 
   image.is_bigendian = 0;
   return true;


### PR DESCRIPTION
On Dashing, you cannot `#include <sensor_msgs/fill_image.hpp>` due to a call to `memcpy` without the `<cstring>` header declaring it. This was fixed already in Foxy in #125 (and `master` in #126); this just cherry-picks that fix into the `dashing` branch.