### PR TITLE
Use underscores instead of dashes in setup.cfg

### DIFF
--- a/sensor_msgs_py/setup.cfg
+++ b/sensor_msgs_py/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/sensor_msgs_py
+script_dir=$base/lib/sensor_msgs_py
 [install]
-install-scripts=$base/lib/sensor_msgs_py
+install_scripts=$base/lib/sensor_msgs_py


### PR DESCRIPTION
To avoid an user-warning when building

https://ci.ros2.org/view/nightly/job/nightly_linux_release/1890/consoleFull#console-section-382