### PR TITLE
Update CompressedImage documentation: add 'tiff' as a supported format

### DIFF
--- a/sensor_msgs/msg/CompressedImage.msg
+++ b/sensor_msgs/msg/CompressedImage.msg
@@ -9,6 +9,6 @@ std_msgs/Header header # Header timestamp should be acquisition time of image
 
 string format                # Specifies the format of the data
                              #   Acceptable values:
-                             #     jpeg, png
+                             #     jpeg, png, tiff
 
 uint8[] data                 # Compressed image buffer


### PR DESCRIPTION
Should be merged after https://github.com/ros-perception/image_transport_plugins/pull/75.