### PR TITLE
Use rosidl_get_typesupport_target()

### DIFF
--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -69,9 +69,8 @@ if(BUILD_TESTING)
     test/test_image_encodings.cpp
     test/test_pointcloud_conversion.cpp
     test/test_pointcloud_iterator.cpp)
-  if(TARGET test_sensor_msgs)
-    rosidl_target_interfaces(test_sensor_msgs ${PROJECT_NAME} "rosidl_typesupport_cpp")
-  endif()
+  rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
+  target_link_libraries(test_sensor_msgs "${cpp_typesupport_target}")
 endif()
 
 ament_export_dependencies(rosidl_default_runtime)


### PR DESCRIPTION
This should fix the warnings in CI. I pushed the branch, but forgot to open a PR. That's why CI in ros2/rosidl#606 passed. Since this has already been tested in CI I think it just needs an approving review.