### PR TITLE
Add equidistant distortion model

### DIFF
--- a/sensor_msgs/include/sensor_msgs/distortion_models.hpp
+++ b/sensor_msgs/include/sensor_msgs/distortion_models.hpp
@@ -43,6 +43,7 @@ namespace distortion_models
 {
 const char PLUMB_BOB[] = "plumb_bob";
 const char RATIONAL_POLYNOMIAL[] = "rational_polynomial";
+const char EQUIDISTANT[] = "equidistant";
 }
 }
 


### PR DESCRIPTION
This is a forward-port from ROS1 noetic:

https://github.com/ros/common_msgs/pull/109

This PR brings the ROS2 list of supported distortion models back into sync with ROS Noetic and is required to forward-port support for this model in vision_opencv:

https://github.com/ros-perception/vision_opencv/pull/358

----------------------------------------------------------------------

*Background info*


The model is based on the following publication:

J. Kannala and S. Brandt (2006). A Generic Camera Model and Calibration Method for Conventional, Wide-Angle, and Fish-Eye Lenses, IEEE Transactions on Pattern Analysis and Machine Intelligence, vol. 28, no.  8, pp. 1335-1340

There are many different names for this distortion model:

* Kannala and Brandt call it "Generic Camera Model". Sometimes they also call it "equidistance projection model".
* Kalibr calls it "equidistant": https://github.com/ethz-asl/kalibr/wiki/supported-models
* Camodocal calls it "kannala-brandt": https://github.com/hengli/camodocal
* OpenCV calls it "fisheye": https://stackoverflow.com/a/34309644/3036576

All of these are just different names for the same model.