### PR TITLE
Add prism type to the SolidPrimitive.msg (#166)

### DIFF
--- a/shape_msgs/msg/SolidPrimitive.msg
+++ b/shape_msgs/msg/SolidPrimitive.msg
@@ -1,10 +1,11 @@
-# Defines box, sphere, cylinder, and cone.
+# Defines box, sphere, cylinder, cone and prism.
 # All shapes are defined to have their bounding boxes centered around 0,0,0.
 
 uint8 BOX=1
 uint8 SPHERE=2
 uint8 CYLINDER=3
 uint8 CONE=4
+uint8 PRISM=5
 
 # The type of the shape
 uint8 type
@@ -35,3 +36,15 @@ uint8 CYLINDER_RADIUS=1
 
 uint8 CONE_HEIGHT=0
 uint8 CONE_RADIUS=1
+
+# For the type PRISM, the center line is oriented along Z axis.
+# The PRISM_HEIGHT component of dimensions gives the
+# height of the prism.
+# The polygon defines the Z axis centered base of the prism.
+# The prism is constructed by extruding the base in +Z and -Z
+# directions by half of the PRISM_HEIGHT
+# Only x and y fields of the points are used in the polygon.
+# Points of the polygon are ordered counter-clockwise.
+
+uint8 PRISM_HEIGHT=0
+geometry_msgs/Polygon[] polygon


### PR DESCRIPTION
This feature adds a `geometry_msgs::msg::Polygon` field to the [shape_msgs/msg/SolidPrimitive.msg](https://github.com/ros2/common_interfaces/blob/master/shape_msgs/msg/SolidPrimitive.msg) in order to represent `PRISM` primitive too.

Explained in detail in #166