### PR TITLE
Add YUV420 and YUV444 to image encodings

### DIFF
--- a/sensor_msgs/include/sensor_msgs/image_encodings.hpp
+++ b/sensor_msgs/include/sensor_msgs/image_encodings.hpp
@@ -100,7 +100,7 @@ const char YUV422_YUY2[] = "yuv422_yuy2";
 // YUV 4:2:0 encodings with an 8-bit depth
 // NV21: https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-yuv-planar.html
 const char NV21[] = "nv21";
-// YUV 4:4:4 encodings with 8-bit depth 
+// YUV 4:4:4 encodings with 8-bit depth
 // NV24: https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-yuv-planar.html
 const char NV24[] = "nv24";
 
@@ -194,7 +194,7 @@ static inline int numChannels(const std::string & encoding)
 
   if (encoding == YUV422 ||
     encoding == YUV422_YUY2 ||
-    encoding == NV21 || 
+    encoding == NV21 ||
     encoding == NV24)
   {
     return 2;
@@ -258,7 +258,7 @@ static inline int bitDepth(const std::string & encoding)
 
   if (encoding == YUV422 ||
     encoding == YUV422_YUY2 ||
-    encoding == NV21 || 
+    encoding == NV21 ||
     encoding == NV24)
   {
     return 8;

--- a/sensor_msgs/include/sensor_msgs/image_encodings.hpp
+++ b/sensor_msgs/include/sensor_msgs/image_encodings.hpp
@@ -98,7 +98,7 @@ const char YUV422[] = "yuv422";
 // YUYV version: http://www.fourcc.org/pixel-format/yuv-yuy2/
 const char YUV422_YUY2[] = "yuv422_yuy2";
 // YUV 4:2:0 encodings with an 8-bit depth
-// NV12: https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-yuv-planar.html
+// NV21: https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-yuv-planar.html
 const char YUV420[] = "yuv420";
 // YUV 4:4:4 encodings with 8-bit depth 
 // NV24: https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-yuv-planar.html

--- a/sensor_msgs/include/sensor_msgs/image_encodings.hpp
+++ b/sensor_msgs/include/sensor_msgs/image_encodings.hpp
@@ -97,6 +97,12 @@ const char BAYER_GRBG16[] = "bayer_grbg16";
 const char YUV422[] = "yuv422";
 // YUYV version: http://www.fourcc.org/pixel-format/yuv-yuy2/
 const char YUV422_YUY2[] = "yuv422_yuy2";
+// YUV 4:2:0 encodings with an 8-bit depth
+// NV12: https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-yuv-planar.html
+const char YUV420[] = "yuv420";
+// YUV 4:4:4 encodings with 8-bit depth 
+// NV24: https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-yuv-planar.html
+const char YUV444[] = "yuv444";
 
 // Prefixes for abstract image encodings
 const char ABSTRACT_ENCODING_PREFIXES[][5] = {
@@ -187,7 +193,9 @@ static inline int numChannels(const std::string & encoding)
   }
 
   if (encoding == YUV422 ||
-    encoding == YUV422_YUY2)
+    encoding == YUV422_YUY2 ||
+    encoding == YUV420 || 
+    encoding == YUV444)
   {
     return 2;
   }
@@ -249,7 +257,9 @@ static inline int bitDepth(const std::string & encoding)
   }
 
   if (encoding == YUV422 ||
-    encoding == YUV422_YUY2)
+    encoding == YUV422_YUY2 ||
+    encoding == YUV420 || 
+    encoding == YUV444)
   {
     return 8;
   }

--- a/sensor_msgs/include/sensor_msgs/image_encodings.hpp
+++ b/sensor_msgs/include/sensor_msgs/image_encodings.hpp
@@ -99,10 +99,10 @@ const char YUV422[] = "yuv422";
 const char YUV422_YUY2[] = "yuv422_yuy2";
 // YUV 4:2:0 encodings with an 8-bit depth
 // NV21: https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-yuv-planar.html
-const char YUV420[] = "yuv420";
+const char NV21[] = "nv21";
 // YUV 4:4:4 encodings with 8-bit depth 
 // NV24: https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-yuv-planar.html
-const char YUV444[] = "yuv444";
+const char NV24[] = "nv24";
 
 // Prefixes for abstract image encodings
 const char ABSTRACT_ENCODING_PREFIXES[][5] = {
@@ -194,8 +194,8 @@ static inline int numChannels(const std::string & encoding)
 
   if (encoding == YUV422 ||
     encoding == YUV422_YUY2 ||
-    encoding == YUV420 || 
-    encoding == YUV444)
+    encoding == NV21 || 
+    encoding == NV24)
   {
     return 2;
   }
@@ -258,8 +258,8 @@ static inline int bitDepth(const std::string & encoding)
 
   if (encoding == YUV422 ||
     encoding == YUV422_YUY2 ||
-    encoding == YUV420 || 
-    encoding == YUV444)
+    encoding == NV21 || 
+    encoding == NV24)
   {
     return 8;
   }


### PR DESCRIPTION
https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-yuv-planar.html

Adding V4L2_PIX_FMT_NV12 (YUV420) and V4L2_PIX_FMT_NV24 (YUV444) formats to image encodings to facilitate hardware accelerator support.