### PR TITLE
Interface packages should fully <depend> on the interface packages that they depend on

### DIFF
--- a/actionlib_msgs/package.xml
+++ b/actionlib_msgs/package.xml
@@ -18,12 +18,10 @@
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
-  <build_depend>std_msgs</build_depend>
+  <depend>builtin_interfaces</depend>
+  <depend>std_msgs</depend>
 
-  <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
 

--- a/diagnostic_msgs/package.xml
+++ b/diagnostic_msgs/package.xml
@@ -18,14 +18,11 @@
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
+  <depend>builtin_interfaces</depend>
+  <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
 
-  <exec_depend>builtin_interfaces</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
 

--- a/geometry_msgs/package.xml
+++ b/geometry_msgs/package.xml
@@ -18,10 +18,9 @@
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>std_msgs</build_depend>
+  <depend>std_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
 

--- a/nav_msgs/package.xml
+++ b/nav_msgs/package.xml
@@ -18,14 +18,11 @@
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
+  <depend>builtin_interfaces</depend>
+  <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
 
-  <exec_depend>builtin_interfaces</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
 

--- a/sensor_msgs/package.xml
+++ b/sensor_msgs/package.xml
@@ -18,14 +18,11 @@
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
+  <depend>builtin_interfaces</depend>
+  <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
 
-  <exec_depend>builtin_interfaces</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/shape_msgs/package.xml
+++ b/shape_msgs/package.xml
@@ -18,9 +18,7 @@
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>geometry_msgs</build_depend>
-
-  <exec_depend>geometry_msgs</exec_depend>
+  <depend>geometry_msgs</depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>

--- a/std_msgs/package.xml
+++ b/std_msgs/package.xml
@@ -18,9 +18,7 @@
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
-
-  <exec_depend>builtin_interfaces</exec_depend>
+  <depend>builtin_interfaces</depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>

--- a/stereo_msgs/package.xml
+++ b/stereo_msgs/package.xml
@@ -18,12 +18,10 @@
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
 

--- a/trajectory_msgs/package.xml
+++ b/trajectory_msgs/package.xml
@@ -18,14 +18,11 @@
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
+  <depend>builtin_interfaces</depend>
+  <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
 
-  <exec_depend>builtin_interfaces</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
 

--- a/visualization_msgs/package.xml
+++ b/visualization_msgs/package.xml
@@ -18,16 +18,12 @@
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
+  <depend>builtin_interfaces</depend>
+  <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
 
-  <exec_depend>builtin_interfaces</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
It seems that the interface packages are missing a `<build_export_depend>` tag for the interface packages that they depend on. The build export dependency is important because downstream packages need to know about the upstream interface dependencies at build time, e.g. to have access to the headers of the upstream interface packages. The lack of this tag made it impossible for [`rosidl_generator_rs`](https://github.com/ros2-rust/ros2_rust/tree/master/rosidl_generator_rs) to correctly identify the build dependency tree for the message packages.

But also, adding `<build_export_depend>` onto the already existing `<build_depend>` and `<exec_depend>` tags is the same as just specifying the `<depend>` tag, so this PR simplifies all the depend tags to just `<depend>`.