### PR TITLE
Port pointcloud creation to numpy.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@
 *.exe
 *.out
 *.app
+
+# Python temporary files
+*.pyc
+__pycache__/

--- a/sensor_msgs_py/package.xml
+++ b/sensor_msgs_py/package.xml
@@ -15,6 +15,7 @@
   <author email="sebastian.grans@gmail.com">Sebastian Grans</author>
 
   <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
+++ b/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
@@ -38,15 +38,14 @@ sensor_msgs/src/sensor_msgs/point_cloud2.py
 """
 
 import array
-import sys
 from collections import namedtuple
-from typing import Iterable, List, NamedTuple, Optional
-
 import numpy as np
 from numpy.lib.recfunctions import (structured_to_unstructured,
                                     unstructured_to_structured)
+import sys
 from sensor_msgs.msg import PointCloud2, PointField
 from std_msgs.msg import Header
+from typing import Iterable, List, NamedTuple, Optional
 
 _DATATYPES = {}
 _DATATYPES[PointField.INT8] = np.dtype(np.int8)
@@ -58,7 +57,7 @@ _DATATYPES[PointField.UINT32] = np.dtype(np.uint32)
 _DATATYPES[PointField.FLOAT32] = np.dtype(np.float32)
 _DATATYPES[PointField.FLOAT64] = np.dtype(np.float64)
 
-DUMMY_FIELD_PREFIX = "unnamed_field"
+DUMMY_FIELD_PREFIX = 'unnamed_field'
 
 
 def read_points(
@@ -92,12 +91,12 @@ def read_points(
     # Keep only the requested fields
     if field_names is not None:
         assert all(field_name in points.dtype.names for field_name in field_names), \
-            "Requests field is not in the fields of the PointCloud!"
+            'Requests field is not in the fields of the PointCloud!'
         # Mask fields
         points = points[list(field_names)]
 
     # Swap array if byte order does not match
-    if bool(sys.byteorder != "little") != bool(cloud.is_bigendian):
+    if bool(sys.byteorder != 'little') != bool(cloud.is_bigendian):
         points = points.byteswap(inplace=True)
 
     # Check if we want to drop points with nan values
@@ -151,7 +150,7 @@ def read_points_numpy(
     :return: Numpy array containing all points.
     """
     assert all(cloud.fields[0].datatype == field.datatype for field in cloud.fields[1:]), \
-        "All fields need to have the same datatype. Use `read_points()` otherwise."
+        'All fields need to have the same datatype. Use `read_points()` otherwise.'
     structured_numpy_array = read_points(
         cloud, field_names, skip_nans, uvs, reshape_organized_cloud)
     return structured_to_unstructured(structured_numpy_array)
@@ -205,8 +204,8 @@ def dtype_from_fields(fields: Iterable[PointField]) -> np.dtype:
         # Datatype as numpy datatype
         datatype = _DATATYPES[field.datatype]
         # Name field
-        if field.name == "":
-            name = f"{DUMMY_FIELD_PREFIX}_{i}"
+        if field.name == '':
+            name = f'{DUMMY_FIELD_PREFIX}_{i}'
         else:
             name = field.name
         # Handle fields with count > 1 by creating subfields with a suffix consiting
@@ -215,10 +214,10 @@ def dtype_from_fields(fields: Iterable[PointField]) -> np.dtype:
         for a in range(field.count):
             # Add suffix if we have multiple subfields
             if field.count > 1:
-                subfield_name = f"{name}_{a}"
+                subfield_name = f'{name}_{a}'
             else:
                 subfield_name = name
-            assert subfield_name not in field_names, "Duplicate field names are not allowed!"
+            assert subfield_name not in field_names, 'Duplicate field names are not allowed!'
             field_names.append(subfield_name)
             # Create new offset that includes subfields
             field_offsets.append(field.offset + a * datatype.itemsize)
@@ -253,16 +252,16 @@ def create_cloud(
         # Check if this is an unstructured array
         if points.dtype.names is None:
             assert all(fields[0].datatype == field.datatype for field in fields[1:]), \
-                "All fields need to have the same datatype. Pass a structured NumPy array \
-                    with multiple dtypes otherwise."
+                'All fields need to have the same datatype. Pass a structured NumPy array \
+                    with multiple dtypes otherwise.'
             # Convert unstructured to structured array
             points = unstructured_to_structured(
                 points,
                 dtype=dtype_from_fields(fields))
         else:
             assert points.dtype == dtype_from_fields(fields), \
-                "PointFields and structured NumPy array dtype do not match for all fields! \
-                    Check their field order, names and types."
+                'PointFields and structured NumPy array dtype do not match for all fields! \
+                    Check their field order, names and types.'
     else:
         # Cast python objects to structured NumPy array (slow)
         points = np.array(
@@ -272,8 +271,8 @@ def create_cloud(
 
     # Handle organized clouds
     assert len(points.shape) <= 2, \
-        "Too many dimensions for organized cloud! \
-            Points can only be organized in max. two dimensional space"
+        'Too many dimensions for organized cloud! \
+            Points can only be organized in max. two dimensional space'
     height = 1
     width = points.shape[0]
     # Check if input points are an organized cloud (2D array of points)
@@ -282,8 +281,8 @@ def create_cloud(
 
     # Convert numpy points to array.array
     memory_view = memoryview(points)
-    casted = memory_view.cast("B")
-    array_array = array.array("B")
+    casted = memory_view.cast('B')
+    array_array = array.array('B')
     array_array.frombytes(casted)
 
     # Put everything together

--- a/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
+++ b/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
@@ -129,8 +129,7 @@ def read_points_numpy(
         uvs: Optional[Iterable] = None,
         reshape_organized_cloud: bool = False) -> np.ndarray:
     """
-    Read equally typed fields from  sensor_msgs.PointCloud2 message
-    as a unstructured numpy array.
+    Read equally typed fields from  sensor_msgs.PointCloud2 message as a unstructured numpy array.
 
     This method is better suited if one wants to perform build math operations
     on e.g. all x,y,z fields.
@@ -187,7 +186,7 @@ def read_points_list(
 
 def dtype_from_fields(fields: Iterable[PointField]) -> np.dtype:
     """
-    Converts a Iterable of sensor_msgs.msg.PointField messages to a np.dtype.
+    Convert a Iterable of sensor_msgs.msg.PointField messages to a np.dtype.
 
     :param fields: The point cloud fields.
                    (Type: iterable of sensor_msgs.msg.PointField)
@@ -217,6 +216,7 @@ def create_cloud(
         points: Iterable) -> PointCloud2:
     """
     Create a sensor_msgs.msg.PointCloud2 message.
+
     :param header: The point cloud header. (Type: std_msgs.msg.Header)
     :param fields: The point cloud fields.
                    (Type: iterable of sensor_msgs.msg.PointField)

--- a/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
+++ b/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
@@ -132,7 +132,7 @@ def read_points_numpy(
     """
     Read equally typed fields from sensor_msgs.PointCloud2 message as a unstructured numpy array.
 
-    This method is better suited if one wants to perform build math operations
+    This method is better suited if one wants to perform math operations
     on e.g. all x,y,z fields.
     But it is limited to fields with the same dtype as unstructured numpy arrays
     only contain one dtype.

--- a/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
+++ b/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
@@ -256,7 +256,7 @@ def create_cloud(
             Points can only be organized in max. two dimensional space"
     height = 1
     width = points.shape[0]
-    # Check if input points where an organized cloud (2D array of points)
+    # Check if input points are an organized cloud (2D array of points)
     if len(points.shape) == 2:
         height = points.shape[1]
 

--- a/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
+++ b/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
@@ -102,7 +102,8 @@ def read_points(
         not_nan_mask = np.ones(len(points), dtype=np.bool)
         for field_name in points.dtype.names:
             # Only keep points without any non values in the mask
-            not_nan_mask = np.logical_and(not_nan_mask, ~np.isnan(points[field_name]))
+            not_nan_mask = np.logical_and(
+                not_nan_mask, ~np.isnan(points[field_name]))
         # Select these points
         points = points[not_nan_mask]
 
@@ -147,7 +148,8 @@ def read_points_numpy(
     """
     assert all(cloud.fields[0].datatype == field.datatype for field in cloud.fields[1:]), \
         "All fields need to have the same datatype. Use `read_points()` otherwise."
-    structured_numpy_array = read_points(cloud, field_names, skip_nans, uvs, reshape_organized_cloud)
+    structured_numpy_array = read_points(
+        cloud, field_names, skip_nans, uvs, reshape_organized_cloud)
     return structured_to_unstructured(structured_numpy_array)
 
 
@@ -233,7 +235,7 @@ def create_cloud(
             # Convert unstructured to structured array
             points = unstructured_to_structured(
                 points,
-                dtype = dtype_from_fields(fields))
+                dtype=dtype_from_fields(fields))
         else:
             assert len(points.dtype.names) == len(fields), \
                 "The number of fields in the structured NumPy array and the PointFields do not match!"
@@ -262,15 +264,15 @@ def create_cloud(
 
     # Put everything together
     return PointCloud2(
-        header = header,
-        height = height,
-        width = width,
-        is_dense = False,
-        is_bigendian = sys.byteorder != 'little',
-        fields = fields,
-        point_step = points.dtype.itemsize,
-        row_step = (points.dtype.itemsize * len(points)) // height,
-        data = points.tobytes())
+        header=header,
+        height=height,
+        width=width,
+        is_dense=False,
+        is_bigendian=sys.byteorder != 'little',
+        fields=fields,
+        point_step=points.dtype.itemsize,
+        row_step=(points.dtype.itemsize * len(points)) // height,
+        data=points.tobytes())
 
 
 def create_cloud_xyz32(header: Header, points: Iterable) -> PointCloud2:

--- a/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
+++ b/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
@@ -39,13 +39,15 @@ sensor_msgs/src/sensor_msgs/point_cloud2.py
 
 import array
 from collections import namedtuple
+import sys
+from typing import Iterable, List, NamedTuple, Optional
+
 import numpy as np
 from numpy.lib.recfunctions import (structured_to_unstructured,
                                     unstructured_to_structured)
-import sys
 from sensor_msgs.msg import PointCloud2, PointField
 from std_msgs.msg import Header
-from typing import Iterable, List, NamedTuple, Optional
+
 
 _DATATYPES = {}
 _DATATYPES[PointField.INT8] = np.dtype(np.int8)

--- a/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
+++ b/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
@@ -238,18 +238,9 @@ def create_cloud(
                 points,
                 dtype=dtype_from_fields(fields))
         else:
-            assert len(points.dtype.names) == len(fields), \
-                "The number of fields in the structured NumPy \
-                    array and the PointFields do not match!"
-
-            all_fields_have_matching_datatypes = all(map(
-                lambda i: points.dtype.formats[i] == _DATATYPES[fields[i].datatype].str,
-                range(len(fields))))
-            assert all_fields_have_matching_datatypes, \
-                "PointField and structured NumPy array do not match data types for all fields! \
-                    Check their order and types."
-            # TODO check if that is the proper way to rename this
-            points.dtype.names = [field.name for field in fields]
+            assert points.dtype == dtype_from_fields(fields), \
+                "PointFields and structured NumPy array dtype do not match for all fields! \
+                    Check their field order, names and types."
     else:
         # Cast python objects to structured NumPy array (slow)
         points = np.array(
@@ -276,7 +267,7 @@ def create_cloud(
         is_bigendian=sys.byteorder != 'little',
         fields=fields,
         point_step=points.dtype.itemsize,
-        row_step=(points.dtype.itemsize * len(points)) // height,
+        row_step=(points.dtype.itemsize * width),
         data=points.tobytes())
 
 

--- a/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
+++ b/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
@@ -85,7 +85,7 @@ def read_points(
         dtype=dtype_from_fields(cloud.fields),
         buffer=cloud.data)
 
-    # Keep the only requested fields
+    # Keep only the requested fields
     if field_names is not None:
         assert all(field_name in points.dtype.names for field_name in field_names), \
             "Requests field is not in the fields of the PointCloud!"

--- a/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
+++ b/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
@@ -74,6 +74,7 @@ def read_points(
                       (Type: Bool, Default: False)
     :param uvs: If specified, then only return the points at the given
         coordinates. (Type: Iterable, Default: None)
+    :param reshape_organized_cloud: Returns the array as an 2D organized point cloud if set.
     :return: Structured NumPy array containing all points.
     """
     assert isinstance(cloud, PointCloud2), \
@@ -129,7 +130,7 @@ def read_points_numpy(
         uvs: Optional[Iterable] = None,
         reshape_organized_cloud: bool = False) -> np.ndarray:
     """
-    Read equally typed fields from  sensor_msgs.PointCloud2 message as a unstructured numpy array.
+    Read equally typed fields from sensor_msgs.PointCloud2 message as a unstructured numpy array.
 
     This method is better suited if one wants to perform build math operations
     on e.g. all x,y,z fields.
@@ -143,6 +144,7 @@ def read_points_numpy(
                       (Type: Bool, Default: False)
     :param uvs: If specified, then only return the points at the given
         coordinates. (Type: Iterable, Default: None)
+    :param reshape_organized_cloud: Returns the array as an 2D organized point cloud if set.
     :return: Numpy array containing all points.
     """
     assert all(cloud.fields[0].datatype == field.datatype for field in cloud.fields[1:]), \

--- a/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
+++ b/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
@@ -39,11 +39,11 @@ sensor_msgs/src/sensor_msgs/point_cloud2.py
 
 import sys
 from collections import namedtuple
-from typing import Iterable, List, Optional, NamedTuple
+from typing import Iterable, List, NamedTuple, Optional
 
 import numpy as np
-from numpy.lib.recfunctions import \
-    structured_to_unstructured, unstructured_to_structured
+from numpy.lib.recfunctions import (structured_to_unstructured,
+                                    unstructured_to_structured)
 from sensor_msgs.msg import PointCloud2, PointField
 from std_msgs.msg import Header
 

--- a/sensor_msgs_py/test/test_point_cloud2.py
+++ b/sensor_msgs_py/test/test_point_cloud2.py
@@ -90,12 +90,12 @@ class TestPointCloud2Methods(unittest.TestCase):
     def test_read_points(self):
         # Test that converting a PointCloud2 to a list, is equivalent to
         # the original list of points.
-        pcd_list = list(point_cloud2.read_points(pcd))
+        pcd_list = list(map(list, point_cloud2.read_points(pcd)))
         self.assertTrue(np.allclose(pcd_list, pylist, equal_nan=True))
 
     def test_read_points_field(self):
         # Test that field selection is working.
-        pcd_list = list(point_cloud2.read_points(pcd, field_names=['x', 'z']))
+        pcd_list = list(map(list, point_cloud2.read_points(pcd, field_names=['x', 'z'])))
         # Check correct shape.
         self.assertTrue(np.array(pcd_list).shape == points[:, [0, 2]].shape)
         # Check "correct" values.
@@ -104,7 +104,7 @@ class TestPointCloud2Methods(unittest.TestCase):
 
     def test_read_points_skip_nan(self):
         # Test that removing NaNs work.
-        pcd_list = list(point_cloud2.read_points(pcd, skip_nans=True))
+        pcd_list = list(map(list, point_cloud2.read_points(pcd, skip_nans=True)))
         points_nonan = points[~np.any(np.isnan(points), axis=1)]
         # Check correct shape
         self.assertTrue(np.array(pcd_list).shape == points_nonan.shape)

--- a/sensor_msgs_py/test/test_point_cloud2.py
+++ b/sensor_msgs_py/test/test_point_cloud2.py
@@ -104,9 +104,9 @@ struct_points = np.array(
     # Make each point a tuple
     list(map(tuple, points)),
     dtype=[
-        ("a", np.float32),
-        ("b", np.float64),
-        ("c", np.uint8),
+        ('a', np.float32),
+        ('b', np.float64),
+        ('c', np.uint8),
     ])
 
 struct_points_itemsize = struct_points.itemsize
@@ -225,7 +225,7 @@ class TestPointCloud2Methods(unittest.TestCase):
         pcd_points_unstructured = structured_to_unstructured(pcd_points)
         self.assertTrue(
             np.allclose(pcd_points_unstructured, points, equal_nan=True))
-        self.assertEqual(pcd_points.dtype.names, ("x_0", "x_1", "x_2"))
+        self.assertEqual(pcd_points.dtype.names, ('x_0', 'x_1', 'x_2'))
 
     def test_create_cloud(self):
         thispcd = point_cloud2.create_cloud(Header(frame_id='frame'),

--- a/sensor_msgs_py/test/test_point_cloud2.py
+++ b/sensor_msgs_py/test/test_point_cloud2.py
@@ -27,21 +27,21 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
+import sys
 import unittest
 
 import numpy as np
-
-from sensor_msgs.msg import PointCloud2
-from sensor_msgs.msg import PointField
+from numpy.lib.recfunctions import structured_to_unstructured
+from sensor_msgs.msg import PointCloud2, PointField
 from sensor_msgs_py import point_cloud2
 from std_msgs.msg import Header
-
 
 pylist = [[0.0, 0.1, 0.2],
           [1.0, 1.1, 1.2],
           [2.0, 2.1, 2.2],
           [3.0, 3.1, 3.2],
-          [4.0, np.nan, 4.2]]
+          [4.0, np.nan, 4.2],
+          [5.0, 5.1, 5.2]]
 points = np.array(pylist, dtype=np.float32)
 
 fields = [PointField(name='x', offset=0, datatype=PointField.FLOAT32, count=1),
@@ -57,7 +57,7 @@ pcd = PointCloud2(
     height=1,
     width=points.shape[0],
     is_dense=False,
-    is_bigendian=False,  # Not sure how to properly determine this.
+    is_bigendian=sys.byteorder != 'little',
     fields=fields,
     point_step=(itemsize * 3),  # Every point consists of three float32s.
     row_step=(itemsize * 3 * points.shape[0]),
@@ -77,11 +77,57 @@ pcd2 = PointCloud2(
     height=1,
     width=points.shape[0],
     is_dense=False,
-    is_bigendian=False,  # Not sure how to properly determine this.
+    is_bigendian=sys.byteorder != 'little',
     fields=fields,
-    point_step=(itemsize * 2),  # Every point consists of three float32s.
+    point_step=(itemsize * 2),  # Every point consists of two float32s.
     row_step=(itemsize * 2 * points.shape[0]),
     data=data
+)
+
+# Organized point cloud (Points are aligned in 2D matrix)
+points3 = points.reshape(2, 3, -1)
+pcd3 = PointCloud2(
+    header=Header(frame_id='frame'),
+    height=points3.shape[1],
+    width=points3.shape[0],
+    is_dense=False,
+    is_bigendian=sys.byteorder != 'little',
+    fields=fields,
+    # Every point consists of three float32s.
+    point_step=(itemsize * points3.shape[-1]),
+    row_step=(itemsize * points3.shape[-1] * points3.shape[0]),
+    data=points3.tobytes()
+)
+
+# Check multiple datatype pointclouds
+struct_points = np.array(
+    # Make each point a tuple
+    list(map(tuple, points)),
+    dtype=[
+        ("a", np.float32),
+        ("b", np.float64),
+        ("c", np.uint8),
+    ])
+
+struct_points_itemsize = struct_points.itemsize
+
+struct_points_fields = [
+    PointField(name='a', offset=0, datatype=PointField.FLOAT32, count=1),
+    PointField(name='b', offset=4, datatype=PointField.FLOAT64, count=1),
+    PointField(name='c', offset=12, datatype=PointField.UINT8, count=1)]
+
+pcd4 = PointCloud2(
+    header=Header(frame_id='frame'),
+    height=1,
+    width=struct_points.shape[0],
+    is_dense=False,
+    is_bigendian=sys.byteorder != 'little',
+    fields=struct_points_fields,
+    # This time a struct array is used.
+    # The itemsize therfore represents the size of a complete point
+    point_step=struct_points_itemsize,
+    row_step=(struct_points_itemsize * points.shape[0]),
+    data=struct_points.tobytes()
 )
 
 
@@ -95,7 +141,9 @@ class TestPointCloud2Methods(unittest.TestCase):
 
     def test_read_points_field(self):
         # Test that field selection is working.
-        pcd_list = list(map(list, point_cloud2.read_points(pcd, field_names=['x', 'z'])))
+        pcd_list = list(map(
+            list,
+            point_cloud2.read_points(pcd, field_names=['x', 'z'])))
         # Check correct shape.
         self.assertTrue(np.array(pcd_list).shape == points[:, [0, 2]].shape)
         # Check "correct" values.
@@ -104,7 +152,9 @@ class TestPointCloud2Methods(unittest.TestCase):
 
     def test_read_points_skip_nan(self):
         # Test that removing NaNs work.
-        pcd_list = list(map(list, point_cloud2.read_points(pcd, skip_nans=True)))
+        pcd_list = list(map(
+            list,
+            point_cloud2.read_points(pcd, skip_nans=True)))
         points_nonan = points[~np.any(np.isnan(points), axis=1)]
         # Check correct shape
         self.assertTrue(np.array(pcd_list).shape == points_nonan.shape)
@@ -117,12 +167,39 @@ class TestPointCloud2Methods(unittest.TestCase):
         # Check that reading a PointCloud2 message to a list is performed
         # correctly.
         points_named = point_cloud2.read_points_list(pcd)
-        self.assertTrue(np.allclose(np.array(points_named), points, equal_nan=True))
+        self.assertTrue(np.allclose(
+            np.array(points_named), points, equal_nan=True))
+
+    def test_read_points_organized(self):
+        # Checks if organized clouds are handled correctly
+        # Test if it is converted into a unorganized one by default
+        pcd_list = list(map(list, point_cloud2.read_points(pcd3)))
+        self.assertTrue(np.allclose(pcd_list, pylist, equal_nan=True))
+        # Test if organization is correctly if requested
+        pcd_points = point_cloud2.read_points(
+            pcd3, reshape_organized_cloud=True)
+        # Because we have a 2d array of points now it is easier to cat it into a
+        # unstructured NumPy array instead of converting it into a list of lists
+        pcd_points = structured_to_unstructured(pcd_points)
+        self.assertTrue(np.allclose(pcd_points, points3, equal_nan=True))
+
+    def test_read_points_numpy(self):
+        # Checks if the deserialization to an unstructured numpy array works
+        pcd_points = point_cloud2.read_points_numpy(pcd)
+        self.assertTrue(np.allclose(pcd_points, points, equal_nan=True))
+
+    def test_read_points_different_types(self):
+        # Checks if the deserialization to an unstructured numpy array works
+        pcd_points = point_cloud2.read_points(pcd4)
+        self.assertTrue(
+            all(np.allclose(pcd_points[name], struct_points[name], equal_nan=True)
+                for name in struct_points.dtype.names))
+        self.assertEqual(struct_points.dtype, pcd_points.dtype)
 
     def test_create_cloud(self):
         thispcd = point_cloud2.create_cloud(Header(frame_id='frame'),
                                             fields, pylist)
-        self.assertTrue(thispcd == pcd)
+        self.assertEqual(thispcd, pcd)
         thispcd = point_cloud2.create_cloud(Header(frame_id='frame2'),
                                             fields, pylist)
         self.assertFalse(thispcd == pcd)
@@ -130,10 +207,28 @@ class TestPointCloud2Methods(unittest.TestCase):
                                             fields2, pylist2)
         self.assertFalse(thispcd == pcd)
 
+    def test_create_cloud_different_types(self):
+        # Check if we are able to create a point cloud with different data
+        thispcd = point_cloud2.create_cloud(
+            Header(frame_id='frame'),
+            struct_points_fields,
+            struct_points)
+        self.assertEqual(thispcd, pcd4)
+
+    def test_create_cloud_xyz32_organized(self):
+        # Checks if organized clouds are handled correctly
+        thispcd = point_cloud2.create_cloud_xyz32(
+            Header(frame_id='frame'),
+            points3)
+        print(thispcd)
+        print(pcd3)
+        self.assertEqual(thispcd, pcd3)
+
     def test_create_cloud_xyz32(self):
-        thispcd = point_cloud2.create_cloud_xyz32(Header(frame_id='frame'),
-                                                  pylist)
-        self.assertTrue(thispcd == pcd)
+        thispcd = point_cloud2.create_cloud_xyz32(
+            Header(frame_id='frame'),
+            pylist)
+        self.assertEqual(thispcd, pcd)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request ports the `PointCloud` creation to NumPy. It should massively increase the performance for large point clouds as no iteration over the points in python is needed and the bytes are taken directly from NumPy.
Still needs some work regarding other field types. Feel free to comment on my implementation. Suggestions are welcome.
Cheers