### PR TITLE
Add sensor_msgs_library target and install headers to include/${PROJECT_NAME}

### DIFF
--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -55,8 +55,20 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-install(DIRECTORY include/${PROJECT_NAME}/
+rosidl_get_typesupport_target(cpp_target "${PROJECT_NAME}" "rosidl_generator_cpp")
+
+add_library(${PROJECT_NAME}_library INTERFACE)
+target_include_directories(${PROJECT_NAME}_library INTERFACE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME}_library INTERFACE
+  "${cpp_target}")
+
+install(DIRECTORY include/
   DESTINATION include/${PROJECT_NAME}
+)
+install(
+  TARGETS ${PROJECT_NAME}_library EXPORT export_${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)
@@ -73,7 +85,12 @@ if(BUILD_TESTING)
   target_link_libraries(test_sensor_msgs "${cpp_typesupport_target}")
 endif()
 
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
+
+# Export modern CMake targets
+ament_export_targets(export_${PROJECT_NAME})
+
 ament_export_dependencies(rosidl_default_runtime)
-ament_export_include_directories(include)
 
 ament_package()


### PR DESCRIPTION
This adds a modern CMake target `sensor_msgs_library` usable downstream as sensor_msgs::sensor_msgs_library and installs headers to a unique include directory as part of ros2/ros2#1150

It might depend on ros2/rosidl#662, I'm not sure.