### PR TITLE
sensor_msgs/Range lacks variance field

### DIFF
--- a/sensor_msgs/msg/Range.msg
+++ b/sensor_msgs/msg/Range.msg
@@ -37,3 +37,7 @@ float32 range           # range data [m]
                         # (Detection too close to the sensor to quantify)
                         # +Inf represents no detection within the fixed distance.
                         # (Object out of range)
+
+float32 variance        # variance of the range sensor
+                        # 0 is interpreted as variance unknown
+

--- a/sensor_msgs/msg/Range.msg
+++ b/sensor_msgs/msg/Range.msg
@@ -40,4 +40,3 @@ float32 range           # range data [m]
 
 float32 variance        # variance of the range sensor
                         # 0 is interpreted as variance unknown
-


### PR DESCRIPTION
Fixes #180

As stated in the original issue, the Range msg lacks the variance field as opposed to most sensor msgs.

A similar issue exist for ros1, and here the discussion about it: https://github.com/ros/common_msgs/issues/142