### PR TITLE
Fix SolidPrimitive.msg to contain a single Polygon

### DIFF
--- a/shape_msgs/msg/SolidPrimitive.msg
+++ b/shape_msgs/msg/SolidPrimitive.msg
@@ -47,4 +47,4 @@ uint8 CONE_RADIUS=1
 # Points of the polygon are ordered counter-clockwise.
 
 uint8 PRISM_HEIGHT=0
-geometry_msgs/Polygon[] polygon
+geometry_msgs/Polygon polygon


### PR DESCRIPTION
Follow up from https://github.com/ros2/common_interfaces/pull/167

In my previous PR I was supposed to add a single `geometry_msgs::msg::Polygon` to the message but I've added an array of it by mistake :man_facepalming: 

It's even a part of humble now :(

This PR fixes it.