### PR TITLE
retain width and height after resize

### DIFF
--- a/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp
+++ b/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp
@@ -125,14 +125,13 @@ inline void PointCloud2Modifier::reserve(size_t size)
 
 inline void PointCloud2Modifier::resize(size_t size)
 {
+  size_t total_size = size * cloud_msg_.point_step;
+  cloud_msg_.data.resize(total_size);
+
   size_t original_size = cloud_msg_.height * cloud_msg_.width;
   if (original_size == size) {
     return;
   }
-
-  size_t total_size = size * cloud_msg_.point_step;
-
-  cloud_msg_.data.resize(total_size);
 
   // Update height/width
   if (cloud_msg_.height == 1) {

--- a/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp
+++ b/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp
@@ -125,12 +125,19 @@ inline void PointCloud2Modifier::reserve(size_t size)
 
 inline void PointCloud2Modifier::resize(size_t size)
 {
-  cloud_msg_.data.resize(size * cloud_msg_.point_step);
+  size_t original_size = cloud_msg_.height * cloud_msg_.width;
+  if (original_size == size) {
+    return;
+  }
+
+  size_t total_size = size * cloud_msg_.point_step;
+
+  cloud_msg_.data.resize(total_size);
 
   // Update height/width
   if (cloud_msg_.height == 1) {
     cloud_msg_.width = static_cast<uint32_t>(size);
-    cloud_msg_.row_step = static_cast<uint32_t>(size * cloud_msg_.point_step);
+    cloud_msg_.row_step = static_cast<uint32_t>(total_size);
   } else {
     if (cloud_msg_.width == 1) {
       cloud_msg_.height = static_cast<uint32_t>(size);
@@ -140,6 +147,15 @@ inline void PointCloud2Modifier::resize(size_t size)
       cloud_msg_.row_step = static_cast<uint32_t>(size * cloud_msg_.point_step);
     }
   }
+}
+
+inline void PointCloud2Modifier::resize(size_t width, size_t height)
+{
+  size_t size = width * height;
+  resize(size);
+
+  cloud_msg_.width = width;
+  cloud_msg_.height = height;
 }
 
 inline void PointCloud2Modifier::clear()

--- a/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.hpp
+++ b/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.hpp
@@ -128,6 +128,11 @@ public:
   void resize(size_t size);
 
   /**
+   * @param size The number of T's for width and height to change the shape of the original sensor_msgs::msg::PointCloud2 by
+   */
+  void resize(size_t width, size_t height);
+
+  /**
    * @brief remove all T's from the original sensor_msgs::msg::PointCloud2
    */
   void clear();


### PR DESCRIPTION
The width and height was modified after this resize call. Now the width and height will be retained if they were set before. A new method is also provided to input the set width and height.

Signed-off-by: tonylitianyu <tonylitianyu@gmail.com>