### PR TITLE
retain width and height after resize for master

### DIFF
--- a/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp
+++ b/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp
@@ -121,21 +121,36 @@ inline void PointCloud2Modifier::reserve(size_t size)
 
 inline void PointCloud2Modifier::resize(size_t size)
 {
-  cloud_msg_.data.resize(size * cloud_msg_.point_step);
+  size_t total_size = size * cloud_msg_.point_step;
+  cloud_msg_.data.resize(total_size);
+
+  size_t original_size = cloud_msg_.height * cloud_msg_.width;
+  if (original_size == size) {
+    return;
+  }
 
   // Update height/width
   if (cloud_msg_.height == 1) {
     cloud_msg_.width = static_cast<uint32_t>(size);
-    cloud_msg_.row_step = static_cast<uint32_t>(size * cloud_msg_.point_step);
+    cloud_msg_.row_step = static_cast<uint32_t>(total_size);
   } else {
     if (cloud_msg_.width == 1) {
       cloud_msg_.height = static_cast<uint32_t>(size);
     } else {
       cloud_msg_.height = 1;
       cloud_msg_.width = static_cast<uint32_t>(size);
-      cloud_msg_.row_step = static_cast<uint32_t>(size * cloud_msg_.point_step);
+      cloud_msg_.row_step = static_cast<uint32_t>(total_size);
     }
   }
+}
+
+inline void PointCloud2Modifier::resize(size_t width, size_t height)
+{
+  size_t size = width * height;
+  resize(size);
+
+  cloud_msg_.width = width;
+  cloud_msg_.height = height;
 }
 
 inline void PointCloud2Modifier::clear()

--- a/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.hpp
+++ b/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.hpp
@@ -127,7 +127,7 @@ public:
 
   /**
    * @param width The new width of the point cloud.
-   * @param height THe new height of the point cloud.
+   * @param height The new height of the point cloud.
    */
   void resize(size_t width, size_t height);
 

--- a/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.hpp
+++ b/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.hpp
@@ -126,6 +126,11 @@ public:
   void resize(size_t size);
 
   /**
+   * @param size The number of T's for width and height to change the shape of the original sensor_msgs::msg::PointCloud2 by
+   */
+  void resize(size_t width, size_t height);
+
+  /**
    * @brief remove all T's from the original sensor_msgs::msg::PointCloud2
    */
   void clear();

--- a/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.hpp
+++ b/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.hpp
@@ -126,7 +126,8 @@ public:
   void resize(size_t size);
 
   /**
-   * @param size The number of T's for width and height to change the shape of the original sensor_msgs::msg::PointCloud2 by
+   * @param width The new width of the point cloud.
+   * @param height THe new height of the point cloud.
    */
   void resize(size_t width, size_t height);
 

--- a/sensor_msgs/test/test_pointcloud_iterator.cpp
+++ b/sensor_msgs/test/test_pointcloud_iterator.cpp
@@ -124,3 +124,51 @@ TEST(sensor_msgs, PointCloud2Iterator)
   }
   EXPECT_EQ(i, n_points);
 }
+
+TEST(sensor_msgs, PointCloud2Resize)
+{
+  // Check if size will retain when width and height given explicitly (width == 1)
+  size_t n_points = 4;
+  sensor_msgs::msg::PointCloud2 cloud_msg_1;
+  cloud_msg_1.height = static_cast<uint32_t>(n_points);
+  cloud_msg_1.width = 1;
+  sensor_msgs::PointCloud2Modifier modifier(cloud_msg_1);
+  modifier.setPointCloud2FieldsByString(2, "xyz", "rgb");
+  modifier.resize(1 * n_points);
+  EXPECT_EQ((unsigned int)1, cloud_msg_1.width);
+  EXPECT_EQ((unsigned int)4, cloud_msg_1.height);
+  modifier.resize(1, n_points);
+  EXPECT_EQ((unsigned int)1, cloud_msg_1.width);
+  EXPECT_EQ((unsigned int)4, cloud_msg_1.height);
+
+  // Check if size will retain when width and height given explicitly (height == 1)
+  size_t n_points2 = 5;
+  sensor_msgs::msg::PointCloud2 cloud_msg_2;
+  cloud_msg_2.height = 1;
+  cloud_msg_2.width = static_cast<uint32_t>(n_points2);
+  sensor_msgs::PointCloud2Modifier modifier2(cloud_msg_2);
+  modifier2.setPointCloud2FieldsByString(2, "xyz", "rgb");
+  modifier2.resize(1 * n_points2);
+  EXPECT_EQ((unsigned int)5, cloud_msg_2.width);
+  EXPECT_EQ((unsigned int)1, cloud_msg_2.height);
+  EXPECT_EQ((unsigned int)160, cloud_msg_2.row_step);
+  modifier2.resize(n_points2, 1);
+  EXPECT_EQ((unsigned int)5, cloud_msg_2.width);
+  EXPECT_EQ((unsigned int)1, cloud_msg_2.height);
+  EXPECT_EQ((unsigned int)160, cloud_msg_2.row_step);
+
+  // Check if resize works when width and height are changed
+  sensor_msgs::msg::PointCloud2 cloud_msg_3;
+  cloud_msg_3.height = 3;
+  cloud_msg_3.width = 3;
+  sensor_msgs::PointCloud2Modifier modifier3(cloud_msg_3);
+  modifier3.setPointCloud2FieldsByString(2, "xyz", "rgb");
+  modifier3.resize(10);
+  EXPECT_EQ((unsigned int)10, cloud_msg_3.width);
+  EXPECT_EQ((unsigned int)1, cloud_msg_3.height);
+  EXPECT_EQ((unsigned int)320, cloud_msg_3.row_step);
+  modifier3.resize(11, 11);
+  EXPECT_EQ((unsigned int)11, cloud_msg_3.width);
+  EXPECT_EQ((unsigned int)11, cloud_msg_3.height);
+  EXPECT_EQ((unsigned int)3872, cloud_msg_3.row_step);
+}

--- a/sensor_msgs/test/test_pointcloud_iterator.cpp
+++ b/sensor_msgs/test/test_pointcloud_iterator.cpp
@@ -135,11 +135,11 @@ TEST(sensor_msgs, PointCloud2Resize)
   sensor_msgs::PointCloud2Modifier modifier(cloud_msg_1);
   modifier.setPointCloud2FieldsByString(2, "xyz", "rgb");
   modifier.resize(1 * n_points);
-  EXPECT_EQ((unsigned int)1, cloud_msg_1.width);
-  EXPECT_EQ((unsigned int)4, cloud_msg_1.height);
+  EXPECT_EQ(static_cast<uint32_t>(1), cloud_msg_1.width);
+  EXPECT_EQ(static_cast<uint32_t>(4), cloud_msg_1.height);
   modifier.resize(1, n_points);
-  EXPECT_EQ((unsigned int)1, cloud_msg_1.width);
-  EXPECT_EQ((unsigned int)4, cloud_msg_1.height);
+  EXPECT_EQ(static_cast<uint32_t>(1), cloud_msg_1.width);
+  EXPECT_EQ(static_cast<uint32_t>(4), cloud_msg_1.height);
 
   // Check if size will retain when width and height given explicitly (height == 1)
   size_t n_points2 = 5;
@@ -149,13 +149,13 @@ TEST(sensor_msgs, PointCloud2Resize)
   sensor_msgs::PointCloud2Modifier modifier2(cloud_msg_2);
   modifier2.setPointCloud2FieldsByString(2, "xyz", "rgb");
   modifier2.resize(1 * n_points2);
-  EXPECT_EQ((unsigned int)5, cloud_msg_2.width);
-  EXPECT_EQ((unsigned int)1, cloud_msg_2.height);
-  EXPECT_EQ((unsigned int)160, cloud_msg_2.row_step);
+  EXPECT_EQ(static_cast<uint32_t>(5), cloud_msg_2.width);
+  EXPECT_EQ(static_cast<uint32_t>(1), cloud_msg_2.height);
+  EXPECT_EQ(static_cast<uint32_t>(160), cloud_msg_2.row_step);
   modifier2.resize(n_points2, 1);
-  EXPECT_EQ((unsigned int)5, cloud_msg_2.width);
-  EXPECT_EQ((unsigned int)1, cloud_msg_2.height);
-  EXPECT_EQ((unsigned int)160, cloud_msg_2.row_step);
+  EXPECT_EQ(static_cast<uint32_t>(5), cloud_msg_2.width);
+  EXPECT_EQ(static_cast<uint32_t>(1), cloud_msg_2.height);
+  EXPECT_EQ(static_cast<uint32_t>(160), cloud_msg_2.row_step);
 
   // Check if resize works when width and height are changed
   sensor_msgs::msg::PointCloud2 cloud_msg_3;
@@ -164,11 +164,11 @@ TEST(sensor_msgs, PointCloud2Resize)
   sensor_msgs::PointCloud2Modifier modifier3(cloud_msg_3);
   modifier3.setPointCloud2FieldsByString(2, "xyz", "rgb");
   modifier3.resize(10);
-  EXPECT_EQ((unsigned int)10, cloud_msg_3.width);
-  EXPECT_EQ((unsigned int)1, cloud_msg_3.height);
-  EXPECT_EQ((unsigned int)320, cloud_msg_3.row_step);
+  EXPECT_EQ(static_cast<uint32_t>(10), cloud_msg_3.width);
+  EXPECT_EQ(static_cast<uint32_t>(1), cloud_msg_3.height);
+  EXPECT_EQ(static_cast<uint32_t>(320), cloud_msg_3.row_step);
   modifier3.resize(11, 11);
-  EXPECT_EQ((unsigned int)11, cloud_msg_3.width);
-  EXPECT_EQ((unsigned int)11, cloud_msg_3.height);
-  EXPECT_EQ((unsigned int)3872, cloud_msg_3.row_step);
+  EXPECT_EQ(static_cast<uint32_t>(11), cloud_msg_3.width);
+  EXPECT_EQ(static_cast<uint32_t>(11), cloud_msg_3.height);
+  EXPECT_EQ(static_cast<uint32_t>(3872), cloud_msg_3.row_step);
 }


### PR DESCRIPTION
Reopen a pull request for the master branch. The width and height were modified after this resize call. Now the width and height will be retained if they were set before. A new method is also provided to input the set width and height.

Signed-off-by: tonylitianyu <tonylitianyu@gmail.com>