### PR TITLE
Cast to uint32_t for pointcloud2 resize method

### DIFF
--- a/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp
+++ b/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp
@@ -149,8 +149,8 @@ inline void PointCloud2Modifier::resize(size_t width, size_t height)
   size_t size = width * height;
   resize(size);
 
-  cloud_msg_.width = width;
-  cloud_msg_.height = height;
+  cloud_msg_.width = static_cast<uint32_t>(width);
+  cloud_msg_.height = static_cast<uint32_t>(height);
 }
 
 inline void PointCloud2Modifier::clear()

--- a/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp
+++ b/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp
@@ -144,13 +144,13 @@ inline void PointCloud2Modifier::resize(size_t size)
   }
 }
 
-inline void PointCloud2Modifier::resize(size_t width, size_t height)
+inline void PointCloud2Modifier::resize(uint32_t width, uint32_t height)
 {
   size_t size = width * height;
   resize(size);
 
-  cloud_msg_.width = static_cast<uint32_t>(width);
-  cloud_msg_.height = static_cast<uint32_t>(height);
+  cloud_msg_.width = width;
+  cloud_msg_.height = height;
 }
 
 inline void PointCloud2Modifier::clear()

--- a/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.hpp
+++ b/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.hpp
@@ -129,7 +129,7 @@ public:
    * @param width The new width of the point cloud.
    * @param height The new height of the point cloud.
    */
-  void resize(size_t width, size_t height);
+  void resize(uint32_t width, uint32_t height);
 
   /**
    * @brief remove all T's from the original sensor_msgs::msg::PointCloud2

--- a/sensor_msgs/test/test_pointcloud_iterator.cpp
+++ b/sensor_msgs/test/test_pointcloud_iterator.cpp
@@ -137,7 +137,7 @@ TEST(sensor_msgs, PointCloud2Resize)
   modifier.resize(1 * n_points);
   EXPECT_EQ(static_cast<uint32_t>(1), cloud_msg_1.width);
   EXPECT_EQ(static_cast<uint32_t>(4), cloud_msg_1.height);
-  modifier.resize(1, n_points);
+  modifier.resize(static_cast<uint32_t>(1), static_cast<uint32_t>(n_points));
   EXPECT_EQ(static_cast<uint32_t>(1), cloud_msg_1.width);
   EXPECT_EQ(static_cast<uint32_t>(4), cloud_msg_1.height);
 
@@ -152,7 +152,7 @@ TEST(sensor_msgs, PointCloud2Resize)
   EXPECT_EQ(static_cast<uint32_t>(5), cloud_msg_2.width);
   EXPECT_EQ(static_cast<uint32_t>(1), cloud_msg_2.height);
   EXPECT_EQ(static_cast<uint32_t>(160), cloud_msg_2.row_step);
-  modifier2.resize(n_points2, 1);
+  modifier2.resize(static_cast<uint32_t>(n_points2), static_cast<uint32_t>(1));
   EXPECT_EQ(static_cast<uint32_t>(5), cloud_msg_2.width);
   EXPECT_EQ(static_cast<uint32_t>(1), cloud_msg_2.height);
   EXPECT_EQ(static_cast<uint32_t>(160), cloud_msg_2.row_step);
@@ -167,7 +167,7 @@ TEST(sensor_msgs, PointCloud2Resize)
   EXPECT_EQ(static_cast<uint32_t>(10), cloud_msg_3.width);
   EXPECT_EQ(static_cast<uint32_t>(1), cloud_msg_3.height);
   EXPECT_EQ(static_cast<uint32_t>(320), cloud_msg_3.row_step);
-  modifier3.resize(11, 11);
+  modifier3.resize(static_cast<uint32_t>(11), static_cast<uint32_t>(11));
   EXPECT_EQ(static_cast<uint32_t>(11), cloud_msg_3.width);
   EXPECT_EQ(static_cast<uint32_t>(11), cloud_msg_3.height);
   EXPECT_EQ(static_cast<uint32_t>(3872), cloud_msg_3.row_step);


### PR DESCRIPTION
cast size_t to uint32_t to resolve msbuild warning

Signed-off-by: tonylitianyu <tonylitianyu@gmail.com>