### PR TITLE
Remove reference to old implementation

### DIFF
--- a/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
+++ b/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
@@ -27,9 +27,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
-"""
-Serialization of sensor_msgs.PointCloud2 messages.
-"""
+# Serialization of sensor_msgs.PointCloud2 messages.
 
 import array
 from collections import namedtuple

--- a/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
+++ b/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
@@ -29,12 +29,6 @@
 
 """
 Serialization of sensor_msgs.PointCloud2 messages.
-
-Author: Tim Field
-ROS 2 port by Sebastian Grans
-File originally ported from:
-https://github.com/ros/common_msgs/blob/f48b00d43cdb82ed9367e0956db332484f676598/
-sensor_msgs/src/sensor_msgs/point_cloud2.py
 """
 
 import array


### PR DESCRIPTION
Remove reference to old implementation and port of said implementation, as the file has been rewritten from scratch since then.

Not high priority, but the reference might cause some confusion and is definitely outdated. Other suggesting regarding a rewording instead of the removal are welcome.