### PR TITLE
Add NV21 and NV24 to colour formats

### DIFF
--- a/sensor_msgs/include/sensor_msgs/image_encodings.hpp
+++ b/sensor_msgs/include/sensor_msgs/image_encodings.hpp
@@ -118,7 +118,8 @@ static inline bool isColor(const std::string & encoding)
   return encoding == RGB8 || encoding == BGR8 ||
          encoding == RGBA8 || encoding == BGRA8 ||
          encoding == RGB16 || encoding == BGR16 ||
-         encoding == RGBA16 || encoding == BGRA16;
+         encoding == RGBA16 || encoding == BGRA16 ||
+         encoding == NV21 || encoding == NV24;
 }
 
 static inline bool isMono(const std::string & encoding)


### PR DESCRIPTION
[NV21](https://www.kernel.org/doc/html/v4.10/media/uapi/v4l/pixfmt-nv12.html) and [NV24](https://www.kernel.org/doc/html/v4.10/media/uapi/v4l/pixfmt-nv24.html) are colour formats according to the kernel documentation. This PR adds them to the list of formats for which `isColor()` returns true.