### PR TITLE
update YUV format codes and documentation

### DIFF
--- a/sensor_msgs/include/sensor_msgs/image_encodings.hpp
+++ b/sensor_msgs/include/sensor_msgs/image_encodings.hpp
@@ -92,17 +92,22 @@ const char BAYER_BGGR16[] = "bayer_bggr16";
 const char BAYER_GBRG16[] = "bayer_gbrg16";
 const char BAYER_GRBG16[] = "bayer_grbg16";
 
-// Miscellaneous
+// YUV formats
 // YUV 4:2:2 encodings with an 8-bit depth
-// UYUV version: http://www.fourcc.org/pixel-format/yuv-uyvy
-const char YUV422[] = "yuv422";
-// YUYV version: http://www.fourcc.org/pixel-format/yuv-yuy2/
-const char YUV422_YUY2[] = "yuv422_yuy2";
+// https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-packed-yuv.html#id1
+// fourcc: UYVY
+const char UYVY[] = "uyvy";
+const char YUV422[] = "yuv422";  // deprecated
+// fourcc: YUYV
+const char YUYV[] = "yuyv";
+const char YUV422_YUY2[] = "yuv422_yuy2";  // deprecated
+
 // YUV 4:2:0 encodings with an 8-bit depth
-// NV21: https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-yuv-planar.html
+// NV21: https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-yuv-planar.html#nv12-nv21-nv12m-and-nv21m
 const char NV21[] = "nv21";
+
 // YUV 4:4:4 encodings with 8-bit depth
-// NV24: https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-yuv-planar.html
+// NV24: https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-yuv-planar.html#nv24-and-nv42
 const char NV24[] = "nv24";
 
 // Prefixes for abstract image encodings
@@ -184,6 +189,8 @@ static inline int numChannels(const std::string & encoding)
 
   if (encoding == YUV422 ||
     encoding == YUV422_YUY2 ||
+    encoding == UYVY ||
+    encoding == YUYV ||
     encoding == NV21 ||
     encoding == NV24)
   {
@@ -234,6 +241,8 @@ static inline int bitDepth(const std::string & encoding)
 
   if (encoding == YUV422 ||
     encoding == YUV422_YUY2 ||
+    encoding == UYVY ||
+    encoding == YUYV ||
     encoding == NV21 ||
     encoding == NV24)
   {


### PR DESCRIPTION
The YUV formats seem to be ambiguous. With this PR, I would like to clarify this and properly document their memory layout. There is no "yuv422_yuy2" format and the "yuv422" format refers to the format code `YU16`. The documentation mentions a "UYUV" format, which does not exist. Additionally, the website http://www.fourcc.org is not reachable anymore.

With the wayback machine, I compared the documented memory layout from http://www.fourcc.org with the one from the Linux kernel documentation from https://www.kernel.org/doc/html/latest/. I found that for the `yuv422` the memory layout described at [fourcc.org](https://web.archive.org/web/20210316221649/https://www.fourcc.org/pixel-format/yuv-uyvy/) matches `V4L2_PIX_FMT_UYVY` at [kernel.org](https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-packed-yuv.html#id1) and [`yuv422_yuy2`](https://web.archive.org/web/20210224214058/https://www.fourcc.org/pixel-format/yuv-yuy2/) matches `V4L2_PIX_FMT_YUYV`.

The NV21 and NV24 formats have unambiguous format codes across the kernel documentation. For the YUV 4:2:2 formats, different sources seem to use different names, hence I propose to use the fourcc instead of an ambiguous name.

See https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/videodev2.h for a list of codes used with video devices.

@sgvandijk Since you added the "yuv422_yuy2" format via https://github.com/ros2/common_interfaces/pull/78, can you comment if my changes make sense to you?