### PR TITLE
Fix read_points_numpy field_names parameter

### DIFF
--- a/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
+++ b/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
@@ -147,7 +147,8 @@ def read_points_numpy(
     :param reshape_organized_cloud: Returns the array as an 2D organized point cloud if set.
     :return: Numpy array containing all points.
     """
-    assert all(cloud.fields[0].datatype == field.datatype for field in cloud.fields[1:]), \
+    assert all(cloud.fields[0].datatype == field.datatype for field in cloud.fields[1:]
+               if field_names is None or field.name in field_names), \
         'All fields need to have the same datatype. Use `read_points()` otherwise.'
     structured_numpy_array = read_points(
         cloud, field_names, skip_nans, uvs, reshape_organized_cloud)

--- a/sensor_msgs_py/test/test_point_cloud2.py
+++ b/sensor_msgs_py/test/test_point_cloud2.py
@@ -154,6 +154,35 @@ pcd5 = PointCloud2(
     data=data
 )
 
+# Point cloud with two matching data-types, and one dissimilar
+struct_points_6 = np.array(
+    # Make each point a tuple
+    list(map(tuple, points)),
+    dtype=[
+        ('a', np.float32),
+        ('b', np.float32),
+        ('c', np.uint8),
+    ])
+
+struct_points_itemsize_6 = struct_points_6.itemsize
+
+struct_points_fields_6 = [
+    PointField(name='a', offset=0, datatype=PointField.FLOAT32, count=1),
+    PointField(name='b', offset=4, datatype=PointField.FLOAT32, count=1),
+    PointField(name='c', offset=8, datatype=PointField.UINT8, count=1)]
+
+pcd6 = PointCloud2(
+    header=Header(frame_id='frame'),
+    height=1,
+    width=struct_points_6.shape[0],
+    is_dense=False,
+    is_bigendian=sys.byteorder != 'little',
+    fields=struct_points_fields_6,
+    point_step=struct_points_itemsize_6,
+    row_step=(struct_points_itemsize_6 * points.shape[0]),
+    data=struct_points_6.tobytes()
+)
+
 
 class TestPointCloud2Methods(unittest.TestCase):
 
@@ -211,6 +240,18 @@ class TestPointCloud2Methods(unittest.TestCase):
         # Checks if the deserialization to an unstructured numpy array works
         pcd_points = point_cloud2.read_points_numpy(pcd)
         self.assertTrue(np.allclose(pcd_points, points, equal_nan=True))
+
+    def test_read_points_numpy_same_types(self):
+        # Checks if the deserialization to an unstructured numpy array throws
+        # assertion exception when data types are not uniform
+        with self.assertRaises(AssertionError):
+            point_cloud2.read_points_numpy(pcd4)
+
+    def test_read_points_numpy_specific_fields(self):
+        # Checks if the deserialization to an unstructured numpy array works
+        # when only selecting certain fields
+        pcd_points = point_cloud2.read_points_numpy(pcd6, field_names=('a', 'b'))
+        self.assertTrue(pcd_points.shape == (6, 2))
 
     def test_read_points_different_types(self):
         # Checks if the deserialization to an unstructured numpy array works


### PR DESCRIPTION
The current `point_cloud2.read_points_numpy` function takes a pointcloud2 message and returns an unstructured numpy array of the points.
There is an assertion test that all fields are the same data type, required for unstructured numpy arrays.
However if you have multiple data types and use the `field_names` parameter to select only a certain subset of fields with a matching data type, all fields are still tested for the same data type and this will fail.
Change fixes this so that if you are using "field_names", only checks the selected fields have matching data types.
Includes a test case to verify that a call with non-uniform field types fails, and a test case for selecting fields with matching types works even when dissimilar types exist in the pointcloud.