### PR TITLE
Image with Camera Info composed message

### DIFF
--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -25,6 +25,7 @@ set(msg_files
   "msg/FluidPressure.msg"
   "msg/Illuminance.msg"
   "msg/Image.msg"
+  "msg/ImageWithCameraInfo.msg"
   "msg/Imu.msg"
   "msg/JointState.msg"
   "msg/Joy.msg"

--- a/sensor_msgs/msg/ImageWithCameraInfo.msg
+++ b/sensor_msgs/msg/ImageWithCameraInfo.msg
@@ -1,0 +1,2 @@
+sensor_msgs/CameraInfo camera_info
+sensor_msgs/Image image


### PR DESCRIPTION
One of the major pain points in running image data over non-ideal links in ROS, namely that the `CameraInfo` and `Image` messages get published separately, and due to the vastly different message sizes, they can fall victim to different retransmission/latency/packet loss (e.g. `CameraInfo` almost certainly fits in one packet or datagram, an `Image` almost certainly does not). The traditional practical solution(s) to this are usually:

 - assume CameraInfo never changes, and you can just use the most recent one
 - define a composite message type that includes both image and camera info (this PR)

(2) is the most robust answer, since it ensures that synchronization between image and camera info is maintained. It would be nice to standardize a composite message type that could then be directly supported in `image_transport` and in visualization tools (e.g. rviz, rqt).

I believe this is not breaking ABI or API, it could be backported to other versions too.