### PR TITLE
Update CompressedImage

### DIFF
--- a/sensor_msgs/msg/CompressedImage.msg
+++ b/sensor_msgs/msg/CompressedImage.msg
@@ -1,13 +1,16 @@
 # This message contains a compressed image.
 
-std_msgs/Header header # Header timestamp should be acquisition time of image
+std_msgs/Header header       # Header timestamp should be acquisition time of image
                              # Header frame_id should be optical frame of camera
                              # origin of frame should be optical center of cameara
                              # +x should point to the right in the image
                              # +y should point down in the image
                              # +z should point into to plane of the image
 
-string format                # Specifies the format of the data
+uint32 height                # image height, that is, number of rows
+uint32 width                 # image width, that is, number of columns
+
+string pixel_format          # Specifies the format of the data
                              # Acceptable values differ by the image transport used:
                              # - compressed_image_transport:
                              #     ORIG_PIXFMT; CODEC compressed [COMPRESSED_PIXFMT]
@@ -37,5 +40,11 @@ string format                # Specifies the format of the data
                              # - Other image transports can store whatever values they
                              #   need for successful decoding of the image. Refer to
                              #   documentation of the other transports for details.
+
+string compression_type      # Compression type used (jpeg, png, theora, etc)
+
+uint64 sequence_number       # sequence number
+uint64 flags                 # flags (for example: KEYFRAME)
+uint8 is_bigendian           # is this data bigendian?
 
 uint8[] data                 # Compressed image buffer


### PR DESCRIPTION
The [compressedImage](https://docs.ros2.org/latest/api/sensor_msgs/msg/CompressedImage.html) message hasn’t been updated [since 2009](https://github.com/ros/common_msgs/commits/noetic-devel/sensor_msgs/msg/CompressedImage.msg) . This message was probably designed for mainly for `jpeg` and `png` according to the history and comments in the message definition.

During this time some other compressedImage types have appeared, for example:
 - [FFMPEGPacket](https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs/blob/rolling/msg/FFMPEGPacket.msg)
 - [Theora](https://docs.ros.org/en/api/theora_image_transport/html/msg/Packet.html)

The idea of this PR is to try to refresh this message type allowing new compression algorithms to set all the required information. 

As a reference, I was working on a [SVTAV1 image transport plugin](https://github.com/ros-perception/image_transport_plugins/pull/161/files) and I had to encode the metadata inside the payload which is ugly.

This new message type will allow to use the same message type in all the `image_transport` plugins (at least released in rolling)
 - ffmpeg
 - Jpeg and png
 - Theora
 - SVTAV1
 - AVIF
 - others ?

FYI @calderpg-tri @IanTheEngineer 