### PR TITLE
Use target qualifier for checking the cpp typesupport exists

### DIFF
--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -64,7 +64,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-if(cpp_typesupport_target)
+if(TARGET "${cpp_typesupport_target}")
   add_library(${PROJECT_NAME}_library INTERFACE)
   target_include_directories(${PROJECT_NAME}_library INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"


### PR DESCRIPTION
Follow up from https://github.com/ros-geographic-info/geographic_info/pull/56#discussion_r1505260952, where I recommend we check this condition based on the `TARGET` keyword. We are expecting a target, not a non-zero length string, so it better expresses intent.

I would like to set the precedent for it here, and then perhaps update the ROS tutorial on this feature.