### PR TITLE
Adds ARROW_STRIP to Marker.msg

### DIFF
--- a/visualization_msgs/msg/Marker.msg
+++ b/visualization_msgs/msg/Marker.msg
@@ -16,6 +16,7 @@ int32 POINTS=8
 int32 TEXT_VIEW_FACING=9
 int32 MESH_RESOURCE=10
 int32 TRIANGLE_LIST=11
+int32 ARROW_STRIP=12
 
 int32 ADD=0
 int32 MODIFY=0
@@ -49,7 +50,7 @@ builtin_interfaces/Duration lifetime
 # If this marker should be frame-locked, i.e. retransformed into its frame every timestep.
 bool frame_locked
 
-# Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, etc.)
+# Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, ARROW_STRIP, etc.)
 geometry_msgs/Point[] points
 # Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, etc.)
 # The number of colors provided must either be 0 or equal to the number of points provided.


### PR DESCRIPTION
This is a rebase of #218 for a clean merge from @rr-tom-noble but since it's been queued so long it's out of date. 

There's a partial implementation in https://github.com/ros2/rviz/pull/972

However I would suggest that we land this in rolling to both keep it in sync with the ROS 1 version that's already added this. And to enable the use of the message with other implementations in the future. If we don't add this now it won't be able to be added for another year. 