### PR TITLE
Add NV12 to pixel formats

### DIFF
--- a/sensor_msgs/include/sensor_msgs/image_encodings.hpp
+++ b/sensor_msgs/include/sensor_msgs/image_encodings.hpp
@@ -103,7 +103,8 @@ const char YUYV[] = "yuyv";
 const char YUV422_YUY2[] = "yuv422_yuy2";  // deprecated
 
 // YUV 4:2:0 encodings with an 8-bit depth
-// NV21: https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-yuv-planar.html#nv12-nv21-nv12m-and-nv21m
+// NV12 & NV21: https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-yuv-planar.html#nv12-nv21-nv12m-and-nv21m
+const char NV12[] = "nv12";
 const char NV21[] = "nv21";
 
 // YUV 4:4:4 encodings with 8-bit depth
@@ -126,7 +127,8 @@ static inline bool isColor(const std::string & encoding)
          encoding == RGBA16 || encoding == BGRA16 ||
          encoding == YUV422 || encoding == YUV422_YUY2 ||
          encoding == UYVY || encoding == YUYV ||
-         encoding == NV21 || encoding == NV24;
+         encoding == NV12 || encoding == NV21 ||
+         encoding == NV24;
 }
 
 static inline bool isMono(const std::string & encoding)
@@ -193,6 +195,7 @@ static inline int numChannels(const std::string & encoding)
     encoding == YUV422_YUY2 ||
     encoding == UYVY ||
     encoding == YUYV ||
+    encoding == NV12 ||
     encoding == NV21 ||
     encoding == NV24)
   {
@@ -245,6 +248,7 @@ static inline int bitDepth(const std::string & encoding)
     encoding == YUV422_YUY2 ||
     encoding == UYVY ||
     encoding == YUYV ||
+    encoding == NV12 ||
     encoding == NV21 ||
     encoding == NV24)
   {


### PR DESCRIPTION
I propose this PR to enable ROS2 support of NV12 pixel format as image encoding. The NV12 pixel format is a common output format of hardware-accelerated decoders. NV12 is quite similar to the NV21 pixel format, with the exception that the order of the interleaving of U and V is reversed. The hardware-accelerated video decoder I currently use only supports NV12 as output pixel format. 

NV12 corresponds to the [FourCC](https://fourcc.org/pixel-format/yuv-nv12/), which was previously recommended as the identifier (see also #204 and #214).

The image_encodings.hpp file has been extended with the necessary additions. 

References to show unambiguousness of the NV12 pixel format:
- V4L2: https://github.com/torvalds/linux/blob/v5.19/include/uapi/linux/videodev2.h#L599
- Kernel: https://github.com/torvalds/linux/blob/v5.19/include/uapi/drm/drm_fourcc.h#L276
- FFmpeg: https://github.com/FFmpeg/FFmpeg/blob/n5.1.2/libavcodec/raw.c#L73
