### PR TITLE
reapply yuv encoding deprecation

### DIFF
--- a/sensor_msgs/include/sensor_msgs/image_encodings.hpp
+++ b/sensor_msgs/include/sensor_msgs/image_encodings.hpp
@@ -122,6 +122,8 @@ const std::regex cv_type_regex("(8|16|32|64)(U|S|F)C([0-9]*)");
 // Utility functions for inspecting an encoding string
 static inline bool isColor(const std::string & encoding)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return encoding == RGB8 || encoding == BGR8 ||
          encoding == RGBA8 || encoding == BGRA8 ||
          encoding == RGB16 || encoding == BGR16 ||
@@ -129,6 +131,7 @@ static inline bool isColor(const std::string & encoding)
          encoding == YUV422 || encoding == YUV422_YUY2 ||
          encoding == UYVY || encoding == YUYV ||
          encoding == NV21 || encoding == NV24;
+#pragma GCC diagnostic pop
 }
 
 static inline bool isMono(const std::string & encoding)
@@ -191,6 +194,8 @@ static inline int numChannels(const std::string & encoding)
     return (m[3] == "") ? 1 : std::atoi(m[3].str().c_str());
   }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   if (encoding == YUV422 ||
     encoding == YUV422_YUY2 ||
     encoding == UYVY ||
@@ -200,6 +205,7 @@ static inline int numChannels(const std::string & encoding)
   {
     return 2;
   }
+#pragma GCC diagnostic pop
 
   throw std::runtime_error("Unknown encoding " + encoding);
   return -1;
@@ -243,6 +249,8 @@ static inline int bitDepth(const std::string & encoding)
     return std::atoi(m[0].str().c_str());
   }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   if (encoding == YUV422 ||
     encoding == YUV422_YUY2 ||
     encoding == UYVY ||
@@ -252,6 +260,7 @@ static inline int bitDepth(const std::string & encoding)
   {
     return 8;
   }
+#pragma GCC diagnostic pop
 
   throw std::runtime_error("Unknown encoding " + encoding);
   return -1;

--- a/sensor_msgs/include/sensor_msgs/image_encodings.hpp
+++ b/sensor_msgs/include/sensor_msgs/image_encodings.hpp
@@ -122,8 +122,13 @@ const std::regex cv_type_regex("(8|16|32|64)(U|S|F)C([0-9]*)");
 // Utility functions for inspecting an encoding string
 static inline bool isColor(const std::string & encoding)
 {
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#else
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   return encoding == RGB8 || encoding == BGR8 ||
          encoding == RGBA8 || encoding == BGRA8 ||
          encoding == RGB16 || encoding == BGR16 ||
@@ -131,7 +136,11 @@ static inline bool isColor(const std::string & encoding)
          encoding == YUV422 || encoding == YUV422_YUY2 ||
          encoding == UYVY || encoding == YUYV ||
          encoding == NV21 || encoding == NV24;
+#ifdef _MSC_VER
+#pragma warning(pop)
+#else
 #pragma GCC diagnostic pop
+#endif
 }
 
 static inline bool isMono(const std::string & encoding)
@@ -194,8 +203,13 @@ static inline int numChannels(const std::string & encoding)
     return (m[3] == "") ? 1 : std::atoi(m[3].str().c_str());
   }
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#else
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   if (encoding == YUV422 ||
     encoding == YUV422_YUY2 ||
     encoding == UYVY ||
@@ -205,7 +219,11 @@ static inline int numChannels(const std::string & encoding)
   {
     return 2;
   }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#else
 #pragma GCC diagnostic pop
+#endif
 
   throw std::runtime_error("Unknown encoding " + encoding);
   return -1;
@@ -249,8 +267,13 @@ static inline int bitDepth(const std::string & encoding)
     return std::atoi(m[0].str().c_str());
   }
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#else
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   if (encoding == YUV422 ||
     encoding == YUV422_YUY2 ||
     encoding == UYVY ||
@@ -260,7 +283,11 @@ static inline int bitDepth(const std::string & encoding)
   {
     return 8;
   }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#else
 #pragma GCC diagnostic pop
+#endif
 
   throw std::runtime_error("Unknown encoding " + encoding);
   return -1;

--- a/sensor_msgs/include/sensor_msgs/image_encodings.hpp
+++ b/sensor_msgs/include/sensor_msgs/image_encodings.hpp
@@ -97,9 +97,11 @@ const char BAYER_GRBG16[] = "bayer_grbg16";
 // https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/pixfmt-packed-yuv.html#id1
 // fourcc: UYVY
 const char UYVY[] = "uyvy";
+[[deprecated("use sensor_msgs::image_encodings::UYVY")]]
 const char YUV422[] = "yuv422";  // deprecated
 // fourcc: YUYV
 const char YUYV[] = "yuyv";
+[[deprecated("use sensor_msgs::image_encodings::YUYV")]]
 const char YUV422_YUY2[] = "yuv422_yuy2";  // deprecated
 
 // YUV 4:2:0 encodings with an 8-bit depth

--- a/sensor_msgs/test/test_image_encodings.cpp
+++ b/sensor_msgs/test/test_image_encodings.cpp
@@ -48,8 +48,8 @@ TEST(sensor_msgs, NumChannels)
   ASSERT_EQ(sensor_msgs::image_encodings::numChannels("64FC"), 1);
   ASSERT_EQ(sensor_msgs::image_encodings::numChannels("64FC3"), 3);
   ASSERT_EQ(sensor_msgs::image_encodings::numChannels("64FC10"), 10);
-  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("yuv422"), 2);
-  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("yuv422_yuy2"), 2);
+  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("uyvy"), 2);
+  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("yuyv"), 2);
 }
 
 TEST(sensor_msgs, bitDepth)
@@ -68,6 +68,6 @@ TEST(sensor_msgs, bitDepth)
   ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("64FC"), 64);
   ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("64FC3"), 64);
   ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("64FC10"), 64);
-  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("yuv422"), 8);
-  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("yuv422_yuy2"), 8);
+  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("uyvy"), 8);
+  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("yuyv"), 8);
 }


### PR DESCRIPTION
This reapplies https://github.com/ros2/common_interfaces/pull/247 with fixes for MSVC.