### PR TITLE
Change comment of percentage in BatteryState.msg

### DIFF
--- a/sensor_msgs/msg/BatteryState.msg
+++ b/sensor_msgs/msg/BatteryState.msg
@@ -40,7 +40,7 @@ float32 current          # Negative when discharging (A)  (If unmeasured NaN)
 float32 charge           # Current charge in Ah  (If unmeasured NaN)
 float32 capacity         # Capacity in Ah (last full capacity)  (If unmeasured NaN)
 float32 design_capacity  # Capacity in Ah (design capacity)  (If unmeasured NaN)
-float32 percentage       # Charge percentage on 0 to 1 range  (If unmeasured NaN)
+float32 percentage       # Charge percentage on 0 to 100 range  (If unmeasured NaN)
 uint8   power_supply_status     # The charging status as reported. Values defined above
 uint8   power_supply_health     # The battery health metric. Values defined above
 uint8   power_supply_technology # The battery chemistry. Values defined above


### PR DESCRIPTION
For the BatteryState percentage to be correctly named, it should be in the range of 0-100. The current naming is misleading, as it suggests the percentage is in the range of 0-1, which is not a percentage, but a fraction.

Another option would be to change the name to `ratio` or `charge_level` and keep the value range to be 0-1, but that would be a breaking change.