### PR TITLE
WIP: Added BaseTrajectory messages definition in trajectory_msgs for mobile base trajectory following

### DIFF
--- a/trajectory_msgs/CMakeLists.txt
+++ b/trajectory_msgs/CMakeLists.txt
@@ -18,6 +18,8 @@ find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
 
 set(msg_files
+  "msg/BaseTrajectory.msg"
+  "msg/BaseTrajectoryPoint.msg"
   "msg/JointTrajectory.msg"
   "msg/JointTrajectoryPoint.msg"
   "msg/MultiDOFJointTrajectory.msg"

--- a/trajectory_msgs/README.md
+++ b/trajectory_msgs/README.md
@@ -5,6 +5,8 @@ This package provides several messages for defining robotic joint trajectories.
 For more information about ROS 2 interfaces, see [docs.ros.org](https://docs.ros.org/en/rolling/Concepts/About-ROS-Interfaces.html).
 
 ## Messages (.msg)
+* [BaseTrajectory](msg/BaseTrajectory.msg): A time-parameterized sequence of poses, velocities, and accelerations for a mobile robot base to follow, typically relative to a fixed global frame.
+* [BaseTrajectoryPoint](msg/BaseTrajectoryPoint.msg): A single target pose, velocity, and acceleration for the robot base at a specific time from the start of the trajectory.
 * [JointTrajectory](msg/JointTrajectory.msg): A coordinated sequence of joint configurations to be reached at prescribed time points.
 * [JointTrajectoryPoint](msg/JointTrajectoryPoint.msg): A single configuration for multiple joints in a JointTrajectory.
 * [MultiDOFJointTrajectory](msg/MultiDOFJointTrajectory.msg): A representation of a multi-dof joint trajectory (each point is a transformation).

--- a/trajectory_msgs/msg/BaseTrajectory.msg
+++ b/trajectory_msgs/msg/BaseTrajectory.msg
@@ -1,0 +1,11 @@
+# The header is used to specify the coordinate frame and the reference time for
+# the trajectory durations
+std_msgs/Header header
+
+# The names of the active waypoint in each trajectory point. These names are
+# ordered and must correspond to the values in each trajectory point.
+string[] waypoint_name
+
+# Array of trajectory points, which describe the poses, velocities,
+# and/or accelerations of the base at each time point.
+BaseTrajectoryPoint[] points

--- a/trajectory_msgs/msg/BaseTrajectoryPoint.msg
+++ b/trajectory_msgs/msg/BaseTrajectoryPoint.msg
@@ -1,0 +1,27 @@
+# Each trajectory point specifies the target pose[, velocity[, acceleration]]
+# for the robot base at a specific time from the trajectory start.
+#
+# This message is analogous to JointTrajectoryPoint, but applies to a mobile
+# base or any frame tied to base_link.
+#
+# This message is particularly useful as an input to a trajectory or path-following
+# controller, where each point specifies the desired base pose, velocity, and
+# acceleration at a given time along the trajectory.
+# The pose, velocity, and acceleration are all expressed in the frame specified
+# by the parent trajectory's header.frame_id (e.g., "map", "odom", or similar).
+
+# Target pose of the robot base (e.g., base_link) in the planning frame.
+geometry_msgs/Pose pose
+
+# Desired velocity of the base at this trajectory point.
+# This includes both linear (m/s) and angular (rad/s) components.
+# Twist is expressed in the same frame as pose.
+geometry_msgs/Twist velocity
+
+# Desired acceleration of the base at this trajectory point.
+# This includes both linear (m/s^2) and angular (rad/s^2) components.
+# Twist is expressed in the same frame as pose.
+geometry_msgs/Twist acceleration
+
+# Desired time from the start of the trajectory to arrive at this point.
+builtin_interfaces/Duration time_from_start


### PR DESCRIPTION
Hi,

I’m proposing two new messages, `BaseTrajectory` and `BaseTrajectoryPoint`, to the `trajectory_msgs` package. These are designed for planning the trajectory of mobile robot bases, rather than joints.

- **`BaseTrajectory`**: A sequence of trajectory points that the robot base should follow over time.
- **`BaseTrajectoryPoint`**: A single point in the trajectory, specifying the target pose, velocity, and acceleration.

These should be useful for trajectory or path-following controllers in mobile robots. Let me know what you think!
