### PR TITLE
add mesh vertex colours and normals

### DIFF
--- a/shape_msgs/CMakeLists.txt
+++ b/shape_msgs/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files
@@ -23,7 +24,7 @@ set(msg_files
 )
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
-  DEPENDENCIES geometry_msgs
+  DEPENDENCIES geometry_msgs std_msgs
   ADD_LINTER_TESTS
 )
 

--- a/shape_msgs/msg/Mesh.msg
+++ b/shape_msgs/msg/Mesh.msg
@@ -6,3 +6,4 @@ MeshTriangle[] triangles
 # The actual vertices that make up the mesh.
 geometry_msgs/Point[] vertices
 std_msgs/ColorRGBA[] vertex_colors
+geometry_msgs/Vector3[] vertex_normals

--- a/shape_msgs/msg/Mesh.msg
+++ b/shape_msgs/msg/Mesh.msg
@@ -5,3 +5,4 @@ MeshTriangle[] triangles
 
 # The actual vertices that make up the mesh.
 geometry_msgs/Point[] vertices
+std_msgs/ColorRGBA[] vertex_colors

--- a/shape_msgs/package.xml
+++ b/shape_msgs/package.xml
@@ -19,6 +19,7 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Description

Add vertex colours and normals to the mesh message definition.

### Is this user-facing behavior change?

Well, the new fields are optional, but the message hash changes, thus rendering previously stored messages (bag files) invalid.

### Did you use Generative AI?

No. I know how to program :-)

### Additional Information

See https://www.open3d.org/docs/latest/python_api/open3d.geometry.TriangleMesh.html for examples of what additional information a mesh may contain and https://github.com/naturerobots/mesh_tools/tree/main/mesh_msgs for prior art.
