### PR TITLE
Adding the Trajectory and trajectoryPoint messages

### DIFF
--- a/nav_msgs/CMakeLists.txt
+++ b/nav_msgs/CMakeLists.txt
@@ -24,6 +24,8 @@ set(msg_files
   "msg/OccupancyGrid.msg"
   "msg/Odometry.msg"
   "msg/Path.msg"
+  "msg/Trajectory.msg"
+  "msg/TrajectoryPoint.msg"
 )
 set(srv_files
   "srv/GetMap.srv"

--- a/nav_msgs/README.md
+++ b/nav_msgs/README.md
@@ -12,6 +12,8 @@ For more information about ROS 2 interfaces, see [docs.ros.org](https://docs.ros
 * [OccupancyGrid](msg/OccupancyGrid.msg): Represents a 2-D grid map, in which each cell represents the probability of occupancy.
 * [Odometry](msg/Odometry.msg): This represents an estimate of a position and velocity in free space.
 * [Path](msg/Path.msg): An array of poses that represents a Path for a robot to follow.
+* [Trajectory](msg/Trajectory.msg): A representation of a trajectory as a series of time-stamped trajectory points.
+* [TrajectoryPoint](msg/TrajectoryPoint.msg): A single point in a trajectory.
 
 ## Services (.srv)
 * [GetMap](srv/GetMap.srv): Get the map as a nav_msgs/OccupancyGrid.

--- a/nav_msgs/msg/Trajectory.msg
+++ b/nav_msgs/msg/Trajectory.msg
@@ -1,0 +1,7 @@
+# An array of trajectory points that represents a trajectory for a robot to follow.
+
+# Indicates the frame_id and timestamp of the trajectory.
+std_msgs/Header header
+
+# Array of trajectory points to follow.
+TrajectoryPoint[] points

--- a/nav_msgs/msg/Trajectory.msg
+++ b/nav_msgs/msg/Trajectory.msg
@@ -1,6 +1,6 @@
 # An array of trajectory points that represents a trajectory for a robot to follow.
 
-# Indicates the frame_id and timestamp of the trajectory.
+# Indicates the frame_id in which the planner ran and timestamp represents when the trajectory was generated.
 std_msgs/Header header
 
 # Array of trajectory points to follow.

--- a/nav_msgs/msg/TrajectoryPoint.msg
+++ b/nav_msgs/msg/TrajectoryPoint.msg
@@ -12,5 +12,5 @@ geometry_msgs/Twist velocity
 # Acceleration of the trajectory (optional, linear.x component is NaN if not set).
 geometry_msgs/Accel acceleration
 
-# Force/Torque to apply at trajectory sample (optional, NaN if not set).
+# Force/Torque to apply at trajectory sample (optional, force.x component is NaN if not set).
 geometry_msgs/Wrench effort

--- a/nav_msgs/msg/TrajectoryPoint.msg
+++ b/nav_msgs/msg/TrajectoryPoint.msg
@@ -9,7 +9,7 @@ geometry_msgs/Pose pose
 # Velocity of the trajectory sample.
 geometry_msgs/Twist velocity
 
-# Acceleration of the trajectory (optional, NaN if not set).
+# Acceleration of the trajectory (optional, linear.x component is NaN if not set).
 geometry_msgs/Accel acceleration
 
 # Force/Torque to apply at trajectory sample (optional, NaN if not set).

--- a/nav_msgs/msg/TrajectoryPoint.msg
+++ b/nav_msgs/msg/TrajectoryPoint.msg
@@ -1,0 +1,16 @@
+# Trajectory point state
+
+# Absolute time and frame of reference of the point along a trajectory
+std_msgs/Header header
+
+# Pose of the trajectory sample.
+geometry_msgs/Pose pose
+
+# Velocity of the trajectory sample.
+geometry_msgs/Twist velocity
+
+# Acceleration of the trajectory (optional, NaN if not set).
+geometry_msgs/Accel acceleration
+
+# Force/Torque to apply at trajectory sample (optional, NaN if not set).
+geometry_msgs/Wrench effort


### PR DESCRIPTION
## Description

This PR introduces a new `nav_msgs/Trajectory` message to compliment `Path` for trajectories in the style of `trajectory_msgs` for manipulation. This will be used on merge in Nav2 for publishing optimal trajectories from MPPI, but has broad use for time-series trajectory planners based on MPC and AI. It has been test run in Nav2 in a `nav2_msgs` version of the same message. 

Fixes https://github.com/ros2/common_interfaces/issues/275

### Is this user-facing behavior change?

N/A, its message

### Did you use Generative AI?

Nope.

### Additional Information

N/A