### PR TITLE
Use IWYU pragma private to avoid IWYU trying to pull in sensor_msgs/impl/point_cloud2_iterator.hpp

### DIFF
--- a/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp
+++ b/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp
@@ -29,6 +29,8 @@
 // This file is originally from:
 // https://github.com/ros/common_msgs/blob/50ee957/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.h
 
+// IWYU pragma: private, include "sensor_msgs/point_cloud2_iterator.hpp"
+
 #ifndef SENSOR_MSGS__IMPL__POINT_CLOUD2_ITERATOR_HPP_
 #define SENSOR_MSGS__IMPL__POINT_CLOUD2_ITERATOR_HPP_
 


### PR DESCRIPTION
## Description

Note: this PR is related to addition of IWYU pragmas in generated messages, see https://github.com/ros2/rosidl/pull/902.

This PR adds `// IWYU pragma: private, include "sensor_msgs/point_cloud2_iterator.hpp"` to the impl file, `sensor_msgs/impl/point_cloud2_iterator.hpp`.

This allows the [IWYU tool](https://github.com/include-what-you-use/include-what-you-use/blob/master/README.md) to know that it shouldn't try to pull in the impl file and should instead rely on the public header.

See documentation here for [IWYU pragma: private](https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-private).

### Is this user-facing behavior change?

Not user-facing in terms of code compilation or runtime.

Yes user-facing when using dev tools like [IWYU](https://github.com/include-what-you-use/include-what-you-use/blob/master/README.md#how-to-run):
 * Before this change, IWYU tries to automatically add an include line for the impl header like this, which is not what we want:
```
my/file.cc should add these lines:
#include <sensor_msgs/impl/point_cloud2_iterator.hpp>
```
 * After this change, the IWYU will accept / expect the user to just include `sensor_msgs/point_cloud2_iterator.hpp`.

### Did you use Generative AI?

No