### PR TITLE
Update BatteryState.msg with Battery Node Information

### DIFF
--- a/sensor_msgs/msg/BatteryState.msg
+++ b/sensor_msgs/msg/BatteryState.msg
@@ -41,14 +41,20 @@ float32 charge           # Current charge in Ah  (If unmeasured NaN)
 float32 capacity         # Capacity in Ah (last full capacity)  (If unmeasured NaN)
 float32 design_capacity  # Capacity in Ah (design capacity)  (If unmeasured NaN)
 float32 percentage       # Charge percentage on 0 to 1 range  (If unmeasured NaN)
+uint8   id               # Identifier for the battery
 uint8   power_supply_status     # The charging status as reported. Values defined above
 uint8   power_supply_health     # The battery health metric. Values defined above
 uint8   power_supply_technology # The battery chemistry. Values defined above
 bool    present          # True if the battery is present
 
 float32[] cell_voltage   # An array of individual cell voltages for each cell in the pack
-                         # If individual voltages unknown but number of cells known set each to NaN
+                         # If individual voltages unknown, but number of cells known, set each to NaN
 float32[] cell_temperature # An array of individual cell temperatures for each cell in the pack
-                           # If individual temperatures unknown but number of cells known set each to NaN
+                           # If individual temperatures unknown, but number of cells known, set each to NaN
 string location          # The location into which the battery is inserted. (slot number or plug)
+string manufacturer      # The name of the manufacturer of the battery
 string serial_number     # The best approximation of the battery serial number
+
+string hw_version        # The hardware version of the battery
+string sw_version        # The software version of the battery
+string fw_version        # The firmware version of the battery

--- a/sensor_msgs/msg/BatteryState.msg
+++ b/sensor_msgs/msg/BatteryState.msg
@@ -41,7 +41,7 @@ float32 charge           # Current charge in Ah  (If unmeasured NaN)
 float32 capacity         # Capacity in Ah (last full capacity)  (If unmeasured NaN)
 float32 design_capacity  # Capacity in Ah (design capacity)  (If unmeasured NaN)
 float32 percentage       # Charge percentage on 0 to 1 range  (If unmeasured NaN)
-uint8   id               # Identifier for the battery
+uint32  id               # Identifier for the battery
 uint8   power_supply_status     # The charging status as reported. Values defined above
 uint8   power_supply_health     # The battery health metric. Values defined above
 uint8   power_supply_technology # The battery chemistry. Values defined above

--- a/sensor_msgs/msg/BatteryState.msg
+++ b/sensor_msgs/msg/BatteryState.msg
@@ -47,6 +47,9 @@ uint8   power_supply_health     # The battery health metric. Values defined abov
 uint8   power_supply_technology # The battery chemistry. Values defined above
 bool    present          # True if the battery is present
 
+uint32  charge_fault     # The current charge fault of the battery, if there is one
+uint32  discharge_fault  # The current discharge fault of the battery, if there is one
+
 float32[] cell_voltage   # An array of individual cell voltages for each cell in the pack
                          # If individual voltages unknown, but number of cells known, set each to NaN
 float32[] cell_temperature # An array of individual cell temperatures for each cell in the pack


### PR DESCRIPTION
## Description

The BatteryState.msg struct is missing a few possible useful pieces of informaton for downstream systems. 

- ID: Could be the CAN ID or some other specifier, which is useful if your publishers do not include the ID baked into the topic.
- Manufacturer: Useful for auto-detection systems that load up a battery configuration based on the type of battery that is communicating with the system.
- fw/sw/hw_version: Good for diagnostics that use checksums to validate the correct versions are loaded on the battery.
- charge/discharge fault: Batteries can sometimes stop charging/discharging if they raise a fault, and their clear conditions can be very specific. For example if an Inventus module goes into OVP, it will not release that fault flag until it goes much lower than the OVP threshold. During this OVP fault, it will NOT charge, so in some situations these fields are critical knowledge for the operation of your battery.

### Is this user-facing behavior change?

It shouldn't affect anything user-facing, but the additions can added to user-facing changes, such as diagnostics.

### Did you use Generative AI?

No.

### Additional Information

This shouldn't be a breaking change, just adding additional members to a message. This felt like the least invasive while still allowing our system to maintain a ROS message rather than decouple and generate our own.
