### PR TITLE
[ADD] missing PointField type entries

### DIFF
--- a/sensor_msgs/msg/PointField.msg
+++ b/sensor_msgs/msg/PointField.msg
@@ -8,6 +8,9 @@ uint8 INT32   = 5
 uint8 UINT32  = 6
 uint8 FLOAT32 = 7
 uint8 FLOAT64 = 8
+uint8 INT64   = 9
+uint8 UINT64  = 10
+uint8 BOOL    = 11
 
 # Common PointField names are x, y, z, intensity, rgb, rgba
 string name      # Name of field


### PR DESCRIPTION
## Description

Adding missing entries in the PointField message definition.
The current PCL uses more types than currently available in the message definition.
However, some Python libraries expect to find the datatype values in the message definition.


Fixes #300 

### Is this user-facing behavior change?
Users may use int64, uint64 and bool in PointClouds and have an easier life decoding them

### Did you use Generative AI?
No

### Additional Information
https://github.com/PointCloudLibrary/pcl/blob/master/common/include/pcl/type_traits.h
this is where the PCL defines the values