### PR TITLE
Add Altitude.msg

### DIFF
--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
 
 set(msg_files
+  "msg/Altitude.msg"
   "msg/BatteryState.msg"
   "msg/CameraInfo.msg"
   "msg/ChannelFloat32.msg"

--- a/sensor_msgs/README.md
+++ b/sensor_msgs/README.md
@@ -16,6 +16,7 @@ This package provides some common C++ functionality relating to manipulating a c
 * [point_field_conversion.hpp](include/sensor_msgs/point_field_conversion.hpp): A type to enum mapping for the different PointField types, and methods to read and write in a PointCloud2 buffer for the different PointField types.
 
 ## Messages (.msg)
+* [Altitude](msg/Altitude.msg): Single vertical position (altitude/depth) measurement.
 * [BatteryState](msg/BatteryState.msg): Describes the power state of the battery.
 * [CameraInfo](msg/CameraInfo.msg): Meta information for a camera.
 * [ChannelFloat32](msg/ChannelFloat32.msg): Holds optional data associated with each point in a PointCloud message.

--- a/sensor_msgs/msg/Altitude.msg
+++ b/sensor_msgs/msg/Altitude.msg
@@ -1,41 +1,34 @@
 # Single vertical position (altitude/depth) measurement.
 #
-# Units & sign (REP-103): meters, +Z up. Negative altitude indicates depth
-# below the chosen reference.
+# Units & sign (REP-103): meters, +Z up. Negative altitude indicates depth.
 #
 # Semantics (REP-105):
-# - 'altitude' is the vertical position along the +Z axis of header.frame_id.
-# - header.frame_id is the frame in which the measurement is expressed
-#   (e.g., base_link, imu_link, map, earth).
+# - 'altitude' is the height (or depth if negative) of the origin of header.frame_id,
+#   measured vertically in the selected 'reference'.
+# - header.frame_id identifies the point this measurement applies to.
 #
 # Reference:
-# The 'reference' field indicates what this measurement is relative to:
-#   REFERENCE_UNKNOWN (0): unspecified or mixed semantics.
-#   REFERENCE_DATUM   (1): relative to a vertical datum / ellipsoid / geoid.
-#                         When used, 'datum' should name the model, e.g.
-#                         "WGS84", "EGM96", "MSL", or a local datum identifier.
-#   REFERENCE_SURFACE (2): relative to a local physical surface (ground, seabed,
-#                         water surface). Typical for AGL/height-above-surface sensors.
+# The 'reference' field indicates what this measurement is relative to.
 #
 # Uncertainty:
 # - 'variance' is the measurement variance in m^2; 0.0 indicates unknown.
 
 # Reference enumeration
 uint8 REFERENCE_UNKNOWN=0
-uint8 REFERENCE_DATUM=1
-uint8 REFERENCE_SURFACE=2
+uint8 REFERENCE_MSL=1            # altitude above mean sea level (as provided by the sensor/system)
+uint8 REFERENCE_WGS84=2          # altitude above WGS84 ellipsoid (matches NavSatFix semantics)
+uint8 REFERENCE_EGM96=3          # altitude relative to EGM96 geoid model
+uint8 REFERENCE_LOCAL_DATUM=4    # altitude relative to a publisher-defined local vertical datum
+uint8 REFERENCE_SURFACE=5        # altitude relative to a local physical surface (ground, seabed, water surface, etc.)
 
-# Timestamp and frame of the measurement
-std_msgs/Header header        # timestamp is when the altitude was measured;
-                              # frame_id is the frame whose +Z defines "up"
+# Timestamp and point of the measurement
+std_msgs/Header header  # stamp: measurement time; frame_id: measurement point
 
 # Scalar vertical position
-float64 altitude              # Vertical position in meters (+Z up); negative for depth
+float64 altitude        # Vertical position in meters (+Z up); negative for depth
 
 # Measurement uncertainty
-float64 variance              # 0 is interpreted as variance unknown
+float64 variance        # 0 is interpreted as variance unknown
 
-# Optional name of the datum/surface
-string datum                  # Name of vertical datum or surface if applicable
-                              # (e.g., "WGS84", "EGM96", "MSL", "GROUND", "SEA_SURFACE");
-                              # empty if unknown or not applicable
+# Which reference 'altitude' is relative to (see REFERENCE_* constants above)
+uint8 reference

--- a/sensor_msgs/msg/Altitude.msg
+++ b/sensor_msgs/msg/Altitude.msg
@@ -1,0 +1,41 @@
+# Single vertical position (altitude/depth) measurement.
+#
+# Units & sign (REP-103): meters, +Z up. Negative altitude indicates depth
+# below the chosen reference.
+#
+# Semantics (REP-105):
+# - 'altitude' is the vertical position along the +Z axis of header.frame_id.
+# - header.frame_id is the frame in which the measurement is expressed
+#   (e.g., base_link, imu_link, map, earth).
+#
+# Reference:
+# The 'reference' field indicates what this measurement is relative to:
+#   REFERENCE_UNKNOWN (0): unspecified or mixed semantics.
+#   REFERENCE_DATUM   (1): relative to a vertical datum / ellipsoid / geoid.
+#                         When used, 'datum' should name the model, e.g.
+#                         "WGS84", "EGM96", "MSL", or a local datum identifier.
+#   REFERENCE_SURFACE (2): relative to a local physical surface (ground, seabed,
+#                         water surface). Typical for AGL/height-above-surface sensors.
+#
+# Uncertainty:
+# - 'variance' is the measurement variance in m^2; 0.0 indicates unknown.
+
+# Reference enumeration
+uint8 REFERENCE_UNKNOWN=0
+uint8 REFERENCE_DATUM=1
+uint8 REFERENCE_SURFACE=2
+
+# Timestamp and frame of the measurement
+std_msgs/Header header        # timestamp is when the altitude was measured;
+                              # frame_id is the frame whose +Z defines "up"
+
+# Scalar vertical position
+float64 altitude              # Vertical position in meters (+Z up); negative for depth
+
+# Measurement uncertainty
+float64 variance              # 0 is interpreted as variance unknown
+
+# Optional name of the datum/surface
+string datum                  # Name of vertical datum or surface if applicable
+                              # (e.g., "WGS84", "EGM96", "MSL", "GROUND", "SEA_SURFACE");
+                              # empty if unknown or not applicable


### PR DESCRIPTION
## Description

Add a new scalar message to sensor_msgs named Altitude.msg, containing a timestamped vertical position z in meters (positive up), with an optional uncertainty. This fills the gap between existing messages that either (a) embed altitude together with latitude/longitude (NavSatFix) or (b) represent barometric pressure or generic ranges rather than altitude itself. The proposed definition mirrors existing scalar messages (e.g., Temperature, Illuminance) that carry a variance field.

Fixes #294 

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

**Intended publishers (examples)**
- Barometric altimeters → `reference=REFERENCE_MSL` (when the sensor/system provides MSL-referenced altitude), or `reference=REFERENCE_LOCAL_DATUM` (when referenced to a publisher-defined local vertical datum).
- GNSS receivers → `reference=REFERENCE_WGS84` (altitude above the WGS84 ellipsoid; matches NavSatFix semantics), or `reference=REFERENCE_EGM96` (if configured to output altitude relative to the EGM96 geoid model).
- Underwater pressure sensors (depth) → `reference=REFERENCE_SURFACE`; report depth as negative altitude.


Before approving or merging, @tfoote requested additional files. I’ll address this as soon as possible, but I won’t have time over the next few weeks. You can see the request [here](https://github.com/ros2/common_interfaces/issues/294#issuecomment-3379003533)

