### PR TITLE
fix sensor msgs deps 

### DIFF
--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(service_msgs REQUIRED)
 
 set(msg_files
   "msg/BatteryState.msg"
@@ -52,7 +53,7 @@ set(srv_files
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   ${srv_files}
-  DEPENDENCIES builtin_interfaces geometry_msgs std_msgs
+  DEPENDENCIES builtin_interfaces geometry_msgs std_msgs service_msgs
   ADD_LINTER_TESTS
 )
 

--- a/sensor_msgs/package.xml
+++ b/sensor_msgs/package.xml
@@ -21,6 +21,7 @@
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>service_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 


### PR DESCRIPTION
## Description

Adds `service_msgs` as a dep of `sensor_msgs` to make dependency explicit (ensure it builds first and is linked in properly).

### Is this user-facing behavior change?

Yes, fixes microxrcedds build.

### Did you use Generative AI?

No

### Additional Information

I was getting errors for `ServiceEventInfo` symbol not being linked (building `microxrcedds` typesupport).

```
Error: Could not load library libsensor_msgs__rosidl_typesupport_microxrcedds_c.so: 
dlopen error: ~/microros_ws/install/sensor_msgs/lib/libsensor_msgs__rosidl_typesupport_microxrcedds_c.so: undefined symbol: 
rosidl_typesupport_microxrcedds_c__get_message_type_support_handle__service_msgs__msg__ServiceEventInfo, at ./src/shared_library.c
```

Found that sensor_msgs wasn't linked to `libservice_msgs__rosidl_typesupport_microxrcedds_c.so` even though it existed.
```
$ ldd install/sensor_msgs/lib/libsensor_msgs__rosidl_typesupport_microxrcedds_c.so | grep libservice_msgs__rosidl_typesupport
libservice_msgs__rosidl_typesupport_fastrtps_c.so => ~/microros_ws/install/service_msgs/lib/libservice_msgs__rosidl_typesupport_fastrtps_c.so (0x0000726fbf805000) 

$ ls install/service_msgs/lib/ | grep libservice_msgs__rosidl_typesupport 
libservice_msgs__rosidl_typesupport_cpp.so 
libservice_msgs__rosidl_typesupport_c.so 
libservice_msgs__rosidl_typesupport_fastrtps_cpp.so 
libservice_msgs__rosidl_typesupport_fastrtps_c.so 
libservice_msgs__rosidl_typesupport_introspection_cpp.so
libservice_msgs__rosidl_typesupport_introspection_c.so 
libservice_msgs__rosidl_typesupport_microxrcedds_cpp.so 
libservice_msgs__rosidl_typesupport_microxrcedds_c.so
```
Rebuilt only `sensor_msgs` in my workspace (while keeping `service_msgs`) and the link showed up fine. Looks like it was just a build order thing.