### PR TITLE
Update Inertia.msg documentation to clarify inertia reference frame

### DIFF
--- a/geometry_msgs/msg/Inertia.msg
+++ b/geometry_msgs/msg/Inertia.msg
@@ -4,7 +4,7 @@ float64 m
 # Center of mass [m]
 geometry_msgs/Vector3 com
 
-# Inertia Tensor [kg-m^2]
+# Inertia Tensor [kg-m^2] about the center of mass
 #     | ixx ixy ixz |
 # I = | ixy iyy iyz |
 #     | ixz iyz izz |


### PR DESCRIPTION
Fixes https://github.com/ros2/common_interfaces/issues/306 by updating `Inertia.msg` to explicitly state that the inertia tensor is expressed about the center of mass.