### PR TITLE
Add `geometry_msgs/msg/VelocityWithCovarianceStamped`

### DIFF
--- a/geometry_msgs/CMakeLists.txt
+++ b/geometry_msgs/CMakeLists.txt
@@ -45,6 +45,7 @@ set(msg_files
   "msg/Vector3.msg"
   "msg/Vector3Stamped.msg"
   "msg/VelocityStamped.msg"
+  "msg/VelocityWithCovarianceStamped.msg"
   "msg/Wrench.msg"
   "msg/WrenchStamped.msg"
 )

--- a/geometry_msgs/README.md
+++ b/geometry_msgs/README.md
@@ -33,6 +33,8 @@ For more information about ROS 2 interfaces, see [docs.ros.org](https://docs.ros
 * [TwistWithCovarianceStamped](msg/TwistWithCovarianceStamped.msg): An estimated twist with reference coordinate frame and timestamp.
 * [Vector3](msg/Vector3.msg): Represents a vector in 3-dimensional free space.
 * [Vector3Stamped](msg/Vector3Stamped.msg): Represents a Vector3 with reference coordinate frame and timestamp.
+* [VelocityStamped](msg/VelocityStamped.msg): A fully-qualified velocity in 3-dimensional space with timestamp.
+* [VelocityWithCovarianceStamped](msg/VelocityWithCovarianceStamped.msg): A fully-qualified velocity in 3-dimensional space with uncertainty and timestamp.
 * [Wrench](msg/Wrench.msg): Represents force in free space, separated into its linear and angular parts.
 * [WrenchStamped](msg/WrenchStamped.msg): A wrench with reference coordinate frame and timestamp.
 

--- a/geometry_msgs/msg/VelocityWithCovarianceStamped.msg
+++ b/geometry_msgs/msg/VelocityWithCovarianceStamped.msg
@@ -9,10 +9,4 @@
 std_msgs/Header header
 string body_frame_id
 string reference_frame_id
-Twist velocity
-
-# Row-major representation of the 6x6 covariance matrix
-# The orientation parameters use a fixed-axis representation.
-# In order, the parameters are:
-# (x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)
-float64[36] covariance
+TwistWithCovariance velocity_with_covariance

--- a/geometry_msgs/msg/VelocityWithCovarianceStamped.msg
+++ b/geometry_msgs/msg/VelocityWithCovarianceStamped.msg
@@ -9,4 +9,4 @@
 std_msgs/Header header
 string body_frame_id
 string reference_frame_id
-TwistWithCovariance velocity_with_covariance
+TwistWithCovariance velocity

--- a/geometry_msgs/msg/VelocityWithCovarianceStamped.msg
+++ b/geometry_msgs/msg/VelocityWithCovarianceStamped.msg
@@ -1,0 +1,18 @@
+# This expresses the timestamped velocity vector of a frame
+# 'body_frame_id' in the reference frame 'reference_frame_id' expressed
+# from arbitrary observation frame 'header.frame_id' with uncertainty.
+# - If 'body_frame_id' and 'header.frame_id' are identical, the velocity
+#   is observed and defined in the local coordinate system of the body,
+#   which is the usual use case in mobile robotics and is also known as
+#   a body twist.
+
+std_msgs/Header header
+string body_frame_id
+string reference_frame_id
+Twist velocity
+
+# Row-major representation of the 6x6 covariance matrix
+# The orientation parameters use a fixed-axis representation.
+# In order, the parameters are:
+# (x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)
+float64[36] covariance

--- a/geometry_msgs/msg/VelocityWithCovarianceStamped.msg
+++ b/geometry_msgs/msg/VelocityWithCovarianceStamped.msg
@@ -1,10 +1,15 @@
-# This expresses the timestamped velocity vector of a frame
-# 'body_frame_id' in the reference frame 'reference_frame_id' expressed
-# from arbitrary observation frame 'header.frame_id' with uncertainty.
-# - If 'body_frame_id' and 'header.frame_id' are identical, the velocity
-#   is observed and defined in the local coordinate system of the body,
-#   which is the usual use case in mobile robotics and is also known as
-#   a body twist.
+# A timestamped velocity of a body whose frame is 'body_frame_id', measured
+# relative to the reference frame 'reference_frame_id', with the velocity and
+# covariance both expressed in the basis of the observation frame
+# 'header.frame_id'.
+#
+# - If 'body_frame_id' and 'header.frame_id' are identical, the velocity and
+#   covariance are expressed in the body's own basis. This is functionally
+#   equivalent to the body-twist convention used by
+#   'geometry_msgs/TwistStamped'.
+#
+# This message is the covariance-bearing analogue of
+# 'geometry_msgs/VelocityStamped'.
 
 std_msgs/Header header
 string body_frame_id


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

Add the `geometry_msgs/msg/VelocityWithCovarianceStamped.msg` message to represent a fully-qualified velocity with uncertainty.  This fills a gap between `geometry_msgs/msg/VelocityStamped`, which provides fully-qualified velocity without uncertainty, and `geometry_msgs/msg/TwistWithCovarianceStamped`, which provides convention-qualified velocity (implicit body and reference frames) with uncertainty.  #322 describes this void in greater detail.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #322.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

Yes, this change adds a new message type to `geometry_msgs` which users will have access to.  It does not modify any existing message types, so use of the new message type should be entirely "opt-in" with backwards compatibility preserved.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

The new `VelocityWithCovarianceStamped` message intentionally duplicates the fields in `VelocityStamped` while adding the covariance field.  There is no clean way that I see to either compose `VelocityStamped` within `VelocityWithCovarianceStamped` or break out common fields to a new message type (e.g., `QualifiedVelocity`) without either modifying existing message definitions or creating a non-standard message structure.
