### PR TITLE
Use structured NumPy points.dtype.itemsize as default point_step in create_cloud (backport #295 to jazzy)

### DIFF
--- a/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
+++ b/sensor_msgs_py/sensor_msgs_py/point_cloud2.py
@@ -266,7 +266,9 @@ def create_cloud(
                 points,
                 dtype=dtype_from_fields(fields, point_step))
         else:
-            assert points.dtype == dtype_from_fields(fields, point_step), \
+            assert points.dtype == dtype_from_fields(
+                fields,
+                point_step or points.dtype.itemsize), \
                 'PointFields and structured NumPy array dtype do not match for all fields! \
                     Check their field order, names and types.'
     else:

--- a/sensor_msgs_py/test/test_point_cloud2.py
+++ b/sensor_msgs_py/test/test_point_cloud2.py
@@ -296,16 +296,17 @@ class TestPointCloud2Methods(unittest.TestCase):
     def test_create_cloud_itemsize(self):
 
         with self.assertRaises(AssertionError):
+            dtype_from_fields = point_cloud2.dtype_from_fields(fields)
             point_cloud2.create_cloud(
                 Header(frame_id='frame'),
                 fields,
-                points_end_padding)
+                points_end_padding,
+                dtype_from_fields.itemsize)
 
         thispcd = point_cloud2.create_cloud(
-            Header(frame_id='frame'),
-            fields,
-            points_end_padding,
-            points_end_padding.dtype.itemsize)
+                Header(frame_id='frame'),
+                fields,
+                points_end_padding)
         self.assertEqual(thispcd.point_step, itemsize_end_padding)
 
     def test_create_cloud_different_types(self):


### PR DESCRIPTION
Backport of #295 to `jazzy`. Fixes #305.

## Problem

On `jazzy`, `create_cloud()` validates a structured NumPy input with:

```python
assert points.dtype == dtype_from_fields(fields, point_step)
```

When the caller does not pass `point_step` — for example `tf2_sensor_msgs.do_transform_cloud()` — `dtype_from_fields(fields, None)` lets NumPy auto-compute the itemsize from the field offsets, producing a *packed* dtype. For a layout with end-padding between fields, such as the `{x, y, z, intensity, ring}` cloud reported in #305 with `point_step=32`, the expected dtype collapses to itemsize=26 while the actual `points.dtype.itemsize` is still 32 (correctly preserved by `read_points()`). The assertion then fires:

> PointFields and structured NumPy array dtype do not match for all fields!

even though the array is perfectly valid.

Contrary to the issue's initial guess, `read_points()` itself is fine — it threads `cloud.point_step` through `dtype_from_fields()` and preserves the itemsize end-to-end. The mismatch happens later, inside `create_cloud()`'s validation, which throws away the array's known itemsize.

## Fix

Fall back to `points.dtype.itemsize` when `point_step` is not supplied — exactly the change already merged on `rolling` in #295.

## Test

`test_create_cloud_itemsize` is updated to mirror the `rolling` version: the negative case now passes an explicit packed itemsize and expects the assertion, and the positive case calls `create_cloud()` with no `point_step` and verifies the resulting `point_step` equals the array's actual itemsize.

I also reproduced the exact #305 scenario locally (`{x,y,z,intensity,ring}`, `point_step=32`, `read_points → copy → create_cloud` round-trip) and confirmed it raises before the patch and passes after.