### PR TITLE
Fix PointCloud2Modifier row_step after organized resize

### DIFF
--- a/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp
+++ b/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp
@@ -153,6 +153,7 @@ inline void PointCloud2Modifier::resize(uint32_t width, uint32_t height)
 
   cloud_msg_.width = width;
   cloud_msg_.height = height;
+  cloud_msg_.row_step = cloud_msg_.width * cloud_msg_.point_step;
 }
 
 inline void PointCloud2Modifier::clear()

--- a/sensor_msgs/test/test_pointcloud_iterator.cpp
+++ b/sensor_msgs/test/test_pointcloud_iterator.cpp
@@ -170,5 +170,5 @@ TEST(sensor_msgs, PointCloud2Resize)
   modifier3.resize(static_cast<uint32_t>(11), static_cast<uint32_t>(11));
   EXPECT_EQ(static_cast<uint32_t>(11), cloud_msg_3.width);
   EXPECT_EQ(static_cast<uint32_t>(11), cloud_msg_3.height);
-  EXPECT_EQ(static_cast<uint32_t>(3872), cloud_msg_3.row_step);
+  EXPECT_EQ(cloud_msg_3.width * cloud_msg_3.point_step, cloud_msg_3.row_step);
 }


### PR DESCRIPTION
## Summary
- Fix `PointCloud2Modifier::resize(width, height)` so organized clouds keep `row_step == width * point_step`.
- Update the existing resize regression test to assert the expected row step contract.

Fixes #320.

<details>
<summary>Before</summary>

```console
$ g++ -std=c++17 <minimal PointCloud2Modifier repro using HEAD>
$ ./before_check
width=11 height=11 point_step=32 row_step=3872 expected_row_step=352 data_size=3872
exit_code=1
```

</details>

<details>
<summary>After</summary>

```console
$ g++ -std=c++17 <minimal PointCloud2Modifier repro using working tree>
$ ./after_check
width=11 height=11 point_step=32 row_step=352 expected_row_step=352 data_size=3872
exit_code=0
```

</details>

## Test plan
- Updated `sensor_msgs/test/test_pointcloud_iterator.cpp` with a regression assertion for organized point clouds.
- `git diff --check`
- Minimal header-only before/after repro shown above.
- `colcon test --packages-select sensor_msgs --ctest-args -R test_sensor_msgs --output-on-failure` could not be run in this environment because `colcon` is not installed.
