### PR TITLE
fix whitespace in CameraInfo

### DIFF
--- a/sensor_msgs/msg/CameraInfo.msg
+++ b/sensor_msgs/msg/CameraInfo.msg
@@ -28,11 +28,11 @@
 
 # Time of image acquisition, camera coordinate frame ID
 std_msgs/Header header # Header timestamp should be acquisition time of image
-                             # Header frame_id should be optical frame of camera
-                             # origin of frame should be optical center of camera
-                             # +x should point to the right in the image
-                             # +y should point down in the image
-                             # +z should point into the plane of the image
+                       # Header frame_id should be optical frame of camera
+                       # origin of frame should be optical center of camera
+                       # +x should point to the right in the image
+                       # +y should point down in the image
+                       # +z should point into the plane of the image
 
 
 #######################################################################
@@ -70,13 +70,13 @@ float64[] d
 # Projects 3D points in the camera coordinate frame to 2D pixel
 # coordinates using the focal lengths (fx, fy) and principal point
 # (cx, cy).
-float64[9]  k # 3x3 row-major matrix
+float64[9] k # 3x3 row-major matrix
 
 # Rectification matrix (stereo cameras only)
 # A rotation matrix aligning the camera coordinate system to the ideal
 # stereo image plane so that epipolar lines in both stereo images are
 # parallel.
-float64[9]  r # 3x3 row-major matrix
+float64[9] r # 3x3 row-major matrix
 
 # Projection/camera matrix
 #     [fx'  0  cx' Tx]

--- a/sensor_msgs/msg/CompressedImage.msg
+++ b/sensor_msgs/msg/CompressedImage.msg
@@ -1,41 +1,41 @@
 # This message contains a compressed image.
 
 std_msgs/Header header # Header timestamp should be acquisition time of image
-                             # Header frame_id should be optical frame of camera
-                             # origin of frame should be optical center of cameara
-                             # +x should point to the right in the image
-                             # +y should point down in the image
-                             # +z should point into to plane of the image
+                       # Header frame_id should be optical frame of camera
+                       # origin of frame should be optical center of cameara
+                       # +x should point to the right in the image
+                       # +y should point down in the image
+                       # +z should point into to plane of the image
 
-string format                # Specifies the format of the data
-                             # Acceptable values differ by the image transport used:
-                             # - compressed_image_transport:
-                             #     ORIG_PIXFMT; CODEC compressed [COMPRESSED_PIXFMT]
-                             #   where:
-                             #   - ORIG_PIXFMT is pixel format of the raw image, i.e.
-                             #     the content of sensor_msgs/Image/encoding with
-                             #     values from include/sensor_msgs/image_encodings.h
-                             #   - CODEC is one of [jpeg, png, tiff]
-                             #   - COMPRESSED_PIXFMT is only appended for color images
-                             #     and is the pixel format used by the compression
-                             #     algorithm. Valid values for jpeg encoding are:
-                             #     [bgr8, rgb8]. Valid values for png encoding are:
-                             #     [bgr8, rgb8, bgr16, rgb16].
-                             #   If the field is empty or does not correspond to the
-                             #   above pattern, the image is treated as bgr8 or mono8
-                             #   jpeg image (depending on the number of channels).
-                             # - compressed_depth_image_transport:
-                             #     ORIG_PIXFMT; compressedDepth CODEC
-                             #   where:
-                             #   - ORIG_PIXFMT is pixel format of the raw image, i.e.
-                             #     the content of sensor_msgs/Image/encoding with
-                             #     values from include/sensor_msgs/image_encodings.h
-                             #     It is usually one of [16UC1, 32FC1].
-                             #   - CODEC is one of [png, rvl]
-                             #   If the field is empty or does not correspond to the
-                             #   above pattern, the image is treated as png image.
-                             # - Other image transports can store whatever values they
-                             #   need for successful decoding of the image. Refer to
-                             #   documentation of the other transports for details.
+string format          # Specifies the format of the data
+                       # Acceptable values differ by the image transport used:
+                       # - compressed_image_transport:
+                       #     ORIG_PIXFMT; CODEC compressed [COMPRESSED_PIXFMT]
+                       #   where:
+                       #   - ORIG_PIXFMT is pixel format of the raw image, i.e.
+                       #     the content of sensor_msgs/Image/encoding with
+                       #     values from include/sensor_msgs/image_encodings.h
+                       #   - CODEC is one of [jpeg, png, tiff]
+                       #   - COMPRESSED_PIXFMT is only appended for color images
+                       #     and is the pixel format used by the compression
+                       #     algorithm. Valid values for jpeg encoding are:
+                       #     [bgr8, rgb8]. Valid values for png encoding are:
+                       #     [bgr8, rgb8, bgr16, rgb16].
+                       #   If the field is empty or does not correspond to the
+                       #   above pattern, the image is treated as bgr8 or mono8
+                       #   jpeg image (depending on the number of channels).
+                       # - compressed_depth_image_transport:
+                       #     ORIG_PIXFMT; compressedDepth CODEC
+                       #   where:
+                       #   - ORIG_PIXFMT is pixel format of the raw image, i.e.
+                       #     the content of sensor_msgs/Image/encoding with
+                       #     values from include/sensor_msgs/image_encodings.h
+                       #     It is usually one of [16UC1, 32FC1].
+                       #   - CODEC is one of [png, rvl]
+                       #   If the field is empty or does not correspond to the
+                       #   above pattern, the image is treated as png image.
+                       # - Other image transports can store whatever values they
+                       #   need for successful decoding of the image. Refer to
+                       #   documentation of the other transports for details.
 
-uint8[] data                 # Compressed image buffer
+uint8[] data           # Compressed image buffer

--- a/sensor_msgs/msg/Image.msg
+++ b/sensor_msgs/msg/Image.msg
@@ -2,25 +2,25 @@
 # (0, 0) is at top-left corner of image
 
 std_msgs/Header header # Header timestamp should be acquisition time of image
-                             # Header frame_id should be optical frame of camera
-                             # origin of frame should be optical center of cameara
-                             # +x should point to the right in the image
-                             # +y should point down in the image
-                             # +z should point into to plane of the image
-                             # If the frame_id here and the frame_id of the CameraInfo
-                             # message associated with the image conflict
-                             # the behavior is undefined
+                       # Header frame_id should be optical frame of camera
+                       # origin of frame should be optical center of cameara
+                       # +x should point to the right in the image
+                       # +y should point down in the image
+                       # +z should point into to plane of the image
+                       # If the frame_id here and the frame_id of the CameraInfo
+                       # message associated with the image conflict
+                       # the behavior is undefined
 
-uint32 height                # image height, that is, number of rows
-uint32 width                 # image width, that is, number of columns
+uint32 height          # image height, that is, number of rows
+uint32 width           # image width, that is, number of columns
 
 # The legal values for encoding are in file include/sensor_msgs/image_encodings.hpp
 # If you want to standardize a new string format, join
 # ros-users@lists.ros.org and send an email proposing a new encoding.
 
-string encoding       # Encoding of pixels -- channel meaning, ordering, size
-                      # taken from the list of strings in include/sensor_msgs/image_encodings.hpp
+string encoding        # Encoding of pixels -- channel meaning, ordering, size
+                       # taken from the list of strings in include/sensor_msgs/image_encodings.hpp
 
-uint8 is_bigendian    # is this data bigendian?
-uint32 step           # Full row length in bytes
-uint8[] data          # actual matrix data, size is (step * rows)
+uint8 is_bigendian     # is this data bigendian?
+uint32 step            # Full row length in bytes
+uint8[] data           # actual matrix data, size is (step * rows)


### PR DESCRIPTION
## Description

This fixes a few whitespace issues in the ´CameraInfo.msg` to align comments. See the ROS 1 definition at https://github.com/ros/common_msgs/blob/noetic-devel/sensor_msgs/msg/CameraInfo.msg for comparison.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
