### PR TITLE
std_srvs: add SetFloat32, SetInt32, SetString, SetUInt8, SetUInt8Array services

### DIFF
--- a/std_srvs/CHANGELOG.rst
+++ b/std_srvs/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package std_srvs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-------------------
+* Add additional std_srvs service definitions:
+  SetFloat32, SetInt32, SetString, SetUInt8, and SetUInt8Array.
+* Contributors: Xavier BROQUERE
+
 5.10.0 (2026-05-06)
 -------------------
 

--- a/std_srvs/CMakeLists.txt
+++ b/std_srvs/CMakeLists.txt
@@ -17,6 +17,11 @@ find_package(rosidl_default_generators REQUIRED)
 set(srv_files
   "srv/Empty.srv"
   "srv/SetBool.srv"
+  "srv/SetFloat32.srv"
+  "srv/SetInt32.srv"
+  "srv/SetString.srv"
+  "srv/SetUInt8.srv"
+  "srv/SetUInt8Array.srv"
   "srv/Trigger.srv"
 )
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/std_srvs/README.md
+++ b/std_srvs/README.md
@@ -7,6 +7,11 @@ For more information about ROS 2 interfaces, see [docs.ros.org](https://docs.ros
 ## Services (.srv)
 * [Empty.srv](srv/Empty.srv): A service containing an empty request and response.
 * [SetBool.srv](srv/SetBool.srv): Service to set a boolean state to true or false, for enabling or disabling hardware for example.
+* [SetFloat32.srv](srv/SetFloat32.srv): Service to set a float32 value, for setting a numeric threshold or gain for example.
+* [SetInt32.srv](srv/SetInt32.srv): Service to set an int32 value, for setting an integer mode or counter for example.
+* [SetString.srv](srv/SetString.srv): Service to set a string value, for selecting a profile or a configuration name for example.
+* [SetUInt8.srv](srv/SetUInt8.srv): Service to set an unsigned 8-bit integer value, for setting a small command code for example.
+* [SetUInt8Array.srv](srv/SetUInt8Array.srv): Service to set an array of unsigned 8-bit integer values, for sending a compact payload for example.
 * [Trigger.srv](srv/Trigger.srv): Service with an empty request header used for triggering the activation or start of a service.
 
 

--- a/std_srvs/srv/SetFloat32.srv
+++ b/std_srvs/srv/SetFloat32.srv
@@ -1,0 +1,4 @@
+float32 data # e.g. for setting a numeric threshold
+---
+bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages

--- a/std_srvs/srv/SetInt32.srv
+++ b/std_srvs/srv/SetInt32.srv
@@ -1,0 +1,4 @@
+int32 data # e.g. for setting an integer mode or counter
+---
+bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages

--- a/std_srvs/srv/SetString.srv
+++ b/std_srvs/srv/SetString.srv
@@ -1,0 +1,4 @@
+string data # e.g. for selecting a profile or a configuration name
+---
+bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages

--- a/std_srvs/srv/SetUInt8.srv
+++ b/std_srvs/srv/SetUInt8.srv
@@ -1,0 +1,4 @@
+uint8 data # e.g. for setting a small command code
+---
+bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages

--- a/std_srvs/srv/SetUInt8Array.srv
+++ b/std_srvs/srv/SetUInt8Array.srv
@@ -1,0 +1,4 @@
+uint8[] data # e.g. for sending a compact payload
+---
+bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages


### PR DESCRIPTION
## Summary

Add SetFloat32, SetInt32, SetString, SetUInt8, and SetUInt8Array service files.

## Description

This PR extends std_srvs with five additional setter-style services and wires them into interface generation.

Changes:
- Add new service definitions:
  - std_srvs/srv/SetFloat32.srv
  - std_srvs/srv/SetInt32.srv
  - std_srvs/srv/SetString.srv
  - std_srvs/srv/SetUInt8.srv
  - std_srvs/srv/SetUInt8Array.srv

- Update std_srvs/CMakeLists.txt to generate interfaces for all new services.
- Update std_srvs/README.md to document the new services with usage-oriented descriptions.
- Update std_srvs/CHANGELOG.rst under Forthcoming.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

<!--
Fixes # (issue)
-->

### Is this user-facing behavior change?

Yes.
New service interface types are now available in std_srvs for package users. Existing services are unchanged.

### Did you use Generative AI?

Yes.
Tool: GitHub Copilot
Model: GPT-5.3-Codex
Usage: Assisted with writing the PR description

### Additional Information

- Change is additive and non-breaking for existing std_srvs users.
- Verified in local workspace with colcon build for std_srvs and a dedicated test package exercising all new services.
