### PR TITLE
[sensor_msgs] Fix row_step when resizing organized PointCloud2

### DIFF
--- a/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp
+++ b/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp
@@ -153,6 +153,7 @@ inline void PointCloud2Modifier::resize(uint32_t width, uint32_t height)
 
   cloud_msg_.width = width;
   cloud_msg_.height = height;
+  cloud_msg_.row_step = cloud_msg_.width * cloud_msg_.point_step;
 }
 
 inline void PointCloud2Modifier::clear()

--- a/sensor_msgs/test/test_pointcloud_iterator.cpp
+++ b/sensor_msgs/test/test_pointcloud_iterator.cpp
@@ -167,8 +167,9 @@ TEST(sensor_msgs, PointCloud2Resize)
   EXPECT_EQ(static_cast<uint32_t>(10), cloud_msg_3.width);
   EXPECT_EQ(static_cast<uint32_t>(1), cloud_msg_3.height);
   EXPECT_EQ(static_cast<uint32_t>(320), cloud_msg_3.row_step);
-  modifier3.resize(static_cast<uint32_t>(11), static_cast<uint32_t>(11));
+  modifier3.resize(static_cast<uint32_t>(11), static_cast<uint32_t>(7));
   EXPECT_EQ(static_cast<uint32_t>(11), cloud_msg_3.width);
-  EXPECT_EQ(static_cast<uint32_t>(11), cloud_msg_3.height);
-  EXPECT_EQ(static_cast<uint32_t>(3872), cloud_msg_3.row_step);
+  EXPECT_EQ(static_cast<uint32_t>(7), cloud_msg_3.height);
+  EXPECT_EQ(static_cast<uint32_t>(11 * cloud_msg_3.point_step), cloud_msg_3.row_step);
+  EXPECT_EQ(static_cast<size_t>(11 * 7 * cloud_msg_3.point_step), cloud_msg_3.data.size());
 }


### PR DESCRIPTION
Fixes ros2/common_interfaces#320

PointCloud2Modifier::resize(width, height) reused the flat resize(size)
path, then updated width and height without recomputing row_step. This
left row_step equal to the total data size instead of one row's byte size.

Set row_step to width * point_step and add a regression test covering a
non-square organized cloud and its backing data size.

Validation:
- git diff --check
- ROS 2 tests not run locally because colcon and ros2 are unavailable.